### PR TITLE
feat(directive): add MockDirective helper function

### DIFF
--- a/src/lib/src/index.ts
+++ b/src/lib/src/index.ts
@@ -13,3 +13,4 @@ export * from './spectator';
 export * from './type-in-element';
 export * from './globals';
 export * from './mock-component';
+export * from './mock-directive';

--- a/src/lib/src/mock-directive.ts
+++ b/src/lib/src/mock-directive.ts
@@ -1,0 +1,24 @@
+import { Directive, EventEmitter } from '@angular/core';
+
+/**
+ * Examples:
+ * MockDirective({ selector: 'some-directive' });
+ * MockDirective({ selector: 'some-directive', inputs: ['some-input', 'some-other-input'] });
+ *
+ */
+export function MockDirective(options: Directive): Directive {
+  const metadata: Directive = {
+    selector: options.selector,
+    inputs: options.inputs,
+    outputs: options.outputs || [],
+    exportAs: options.exportAs || ''
+  };
+
+  class Mock {}
+
+  metadata.outputs.forEach(method => {
+    Mock.prototype[method] = new EventEmitter<any>();
+  });
+
+  return Directive(metadata)(Mock as any);
+}


### PR DESCRIPTION
Thanks for the library, it's a great way of making my unit tests more concise! However I encountered some problems when trying to mock directives. I couldn't mock them with `MockComponent` because they were being applied to an element that already had a component registered on it. So this commit adds a `MockDirective` class that is exactly symmetrical to `MockComponent`.