### PR TITLE
feat(mock-component): content projection for default MockComponent

### DIFF
--- a/src/lib/src/mock-component.ts
+++ b/src/lib/src/mock-component.ts
@@ -9,7 +9,7 @@ import { Component, EventEmitter } from '@angular/core';
 export function MockComponent(options: Component): Component {
   const metadata: Component = {
     selector: options.selector,
-    template: options.template || '',
+    template: options.template || '<ng-content></ng-content>',
     inputs: options.inputs,
     outputs: options.outputs || [],
     exportAs: options.exportAs || ''


### PR DESCRIPTION
This changes the default template for `MockComponent` from `''` to `'<ng-content></ng-content>'`, so that the content of mocked components are projected by default. Usually you want to test the projected contents as well, because they are part of their host component.