### PR TITLE
fix(host): componentProviders should not always be overwritten

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { AsyncComponent } from "./async/async.component";
 import { DomSelectorsComponent } from "./dom-selectors/dom-selectors.component";
 import { HelloComponent } from "./hello/hello.component";
 import { AsyncInputComponent } from "./async-input/async-input.component";
+import { ComponentWithoutOverwrittenProvidersComponent } from "./no-overwritten-providers/no-overwritten-providers.component";
 
 @NgModule({
   declarations: [
@@ -45,7 +46,8 @@ import { AsyncInputComponent } from "./async-input/async-input.component";
     AsyncComponent,
     DomSelectorsComponent,
     HelloComponent,
-    AsyncInputComponent
+    AsyncInputComponent,
+    ComponentWithoutOverwrittenProvidersComponent
   ],
   entryComponents: [DynamicComponent],
   imports: [BrowserModule, HttpClientModule, ReactiveFormsModule],

--- a/src/app/no-overwritten-providers/dummy.service.ts
+++ b/src/app/no-overwritten-providers/dummy.service.ts
@@ -1,0 +1,3 @@
+export class DummyService {
+  constructor() {}
+}

--- a/src/app/no-overwritten-providers/no-overwritten-providers.component.spec.ts
+++ b/src/app/no-overwritten-providers/no-overwritten-providers.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentWithoutOverwrittenProvidersComponent } from "./no-overwritten-providers.component";
+import { createHostComponentFactory } from "../../lib/src/host";
+
+describe("ComponentWithoutOverwrittenProvidersComponent", () => {
+  describe("should not overwrite component's providers and work using createHostComponentFactory ", () => {
+    let createHost = createHostComponentFactory({
+      component: ComponentWithoutOverwrittenProvidersComponent
+    });
+
+    it("with options", () => {
+      const { component } = createHost(`
+        <app-component-without-overwritten-providers>
+        </app-component-without-overwritten-providers>
+      `);
+
+      expect(component).toBeDefined();
+      expect(component.dummy).toBeDefined();
+    });
+
+    it("with component", () => {
+      createHost = createHostComponentFactory(
+        ComponentWithoutOverwrittenProvidersComponent
+      );
+
+      const { component } = createHost(`
+        <app-component-without-overwritten-providers>
+        </app-component-without-overwritten-providers>
+      `);
+
+      expect(component).toBeDefined();
+      expect(component.dummy).toBeDefined();
+    });
+  });
+});

--- a/src/app/no-overwritten-providers/no-overwritten-providers.component.ts
+++ b/src/app/no-overwritten-providers/no-overwritten-providers.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { DummyService } from "./dummy.service";
+
+@Component({
+  selector: "app-component-without-overwritten-providers",
+  template: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [],
+  providers: [
+    {
+      provide: DummyService,
+      useValue: new DummyService()
+    }
+  ]
+})
+export class ComponentWithoutOverwrittenProvidersComponent {
+  constructor(public dummy: DummyService) {}
+}

--- a/src/lib/src/config.ts
+++ b/src/lib/src/config.ts
@@ -31,7 +31,6 @@ const defaultOptions: SpectatorOptions<any, any> = {
   shallow: false,
   host: HostComponent,
   entryComponents: [],
-  componentProviders: [],
   mocks: []
 };
 
@@ -49,7 +48,6 @@ export function initialModule<T, C = HostComponent>(options: SpectatorOptions<T,
       imports: [NoopAnimationsModule],
       schemas: [],
       providers: [],
-      componentProviders: [],
       entryComponents: []
     };
   } else {
@@ -61,7 +59,7 @@ export function initialModule<T, C = HostComponent>(options: SpectatorOptions<T,
       imports: [merged.disableAnimations ? NoopAnimationsModule : [], ...(merged.imports || [])],
       schemas: [merged.shallow ? NO_ERRORS_SCHEMA : []],
       providers: [...(merged.providers || [])],
-      componentProviders: [merged.componentProviders || []],
+      componentProviders: merged.componentProviders ? [merged.componentProviders] : undefined,
       entryComponents: [merged.entryComponents]
     };
 

--- a/src/lib/src/host.ts
+++ b/src/lib/src/host.ts
@@ -82,11 +82,13 @@ export function createHostComponentFactory<C, H = HostComponent>(options: Specta
 
     TestBed.overrideComponent(host, { set: { template: template } });
 
-    TestBed.overrideComponent(component, {
-      set: {
-        providers: [moduleMetadata.componentProviders]
-      }
-    });
+    if (moduleMetadata.componentProviders) {
+      TestBed.overrideComponent(component, {
+        set: {
+          providers: [moduleMetadata.componentProviders]
+        }
+      });
+    }
 
     const spectatorWithHost = new SpectatorWithHost<C, H>();
     spectatorWithHost.hostFixture = TestBed.createComponent(host);

--- a/src/lib/src/spectator.ts
+++ b/src/lib/src/spectator.ts
@@ -28,23 +28,21 @@ export function createTestComponentFactory<T>(options: SpectatorOptions<T> | Typ
     jasmine.addMatchers(customMatchers as any);
   });
 
-  beforeEach(
-    async(() => {
-      @NgModule({
-        entryComponents: [moduleMetadata.entryComponents ? moduleMetadata.entryComponents : []]
-      })
-      class EntryComponentModule {}
-
-      moduleMetadata.imports = [moduleMetadata.imports ? moduleMetadata.imports : [], EntryComponentModule];
-      TestBed.configureTestingModule(moduleMetadata)
-        .overrideComponent(component, {
-          set: {
-            providers: [moduleMetadata.componentProviders]
-          }
-        })
-        .compileComponents();
+  beforeEach(async(() => {
+    @NgModule({
+      entryComponents: [moduleMetadata.entryComponents ? moduleMetadata.entryComponents : []]
     })
-  );
+    class EntryComponentModule {}
+
+    moduleMetadata.imports = [moduleMetadata.imports ? moduleMetadata.imports : [], EntryComponentModule];
+    TestBed.configureTestingModule(moduleMetadata)
+      .overrideComponent(component, {
+        set: {
+          providers: moduleMetadata.componentProviders ? [moduleMetadata.componentProviders] : undefined
+        }
+      })
+      .compileComponents();
+  }));
 
   return (componentParameters: Partial<T> = {}, detectChanges = true) => {
     const spectator = new Spectator<T>();


### PR DESCRIPTION
Since commit https://github.com/NetanelBasal/spectator/commit/ef84b1679f4bf1a7f9cb6de46c4f30cfcb14c1ec, it is required to set componentProviders even if I'm not mocking anything in the component scope.
What I suggest is not to need to declare componentProviders in case I do not mock anything.

Before you could not inject DumyService unless you declare it in componentProviders as well