### PR TITLE
fix(service): loosen type restrictions on SpectatorService.get

### DIFF
--- a/src/lib/src/service.ts
+++ b/src/lib/src/service.ts
@@ -47,8 +47,8 @@ export function createService<S>(options: Params<S> | Type<S>): SpectatorService
     get service(): S {
       return TestBed.get(service);
     },
-    get<T>(provider: Provider): T & SpyObject<T> {
-      return TestBed.get(provider);
+    get<T>(token: any): T & SpyObject<T> {
+      return TestBed.get(token);
     }
   };
 }


### PR DESCRIPTION
This aligns the typings of `SpectatorService.get` with the underlying `TestBed.get` so it can be called with arbitrary injection tokens (e.g. abstract classes).