### PR TITLE
Mock provider properties

### DIFF
--- a/projects/spectator/jest/src/mock.ts
+++ b/projects/spectator/jest/src/mock.ts
@@ -3,8 +3,8 @@ import { CompatibleSpy, SpyObject as BaseSpyObject, installProtoMethods } from '
 
 export type SpyObject<T> = BaseSpyObject<T> & { [P in keyof T]: T[P] & jest.Mock<T> };
 
-export function createSpyObject<T>(type: Type<T>): SpyObject<T> {
-  const mock: any = {};
+export function createSpyObject<T>(type: Type<T>, template?: Partial<Record<keyof T, any>>): SpyObject<T> {
+  const mock: any = template || {};
 
   installProtoMethods(mock, type.prototype, () => {
     const jestFn = jest.fn();
@@ -30,11 +30,11 @@ export function createSpyObject<T>(type: Type<T>): SpyObject<T> {
   return mock;
 }
 
-export function mockProvider<T>(type: Type<T>): Provider {
+export function mockProvider<T>(type: Type<T>, properties?: Partial<Record<keyof T, any>>): Provider {
   return {
     provide: type,
     useFactory: function() {
-      return createSpyObject(type);
+      return createSpyObject(type, properties);
     }
   };
 }

--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -34,8 +34,8 @@ export function installProtoMethods(mock: any, proto: any, createSpyFn: Function
   return mock;
 }
 
-export function createSpyObject<T>(type: Type<T>): SpyObject<T> {
-  const mock: any = {};
+export function createSpyObject<T>(type: Type<T>, template?: Partial<Record<keyof T, any>>): SpyObject<T> {
+  const mock: any = template || {};
 
   return installProtoMethods(mock, type.prototype, name => {
     const newSpy: CompatibleSpy = jasmine.createSpy(name) as any;
@@ -48,11 +48,11 @@ export function createSpyObject<T>(type: Type<T>): SpyObject<T> {
   });
 }
 
-export function mockProvider<T>(type: Type<T>): Provider {
+export function mockProvider<T>(type: Type<T>, properties?: Partial<Record<keyof T, any>>): Provider {
   return {
     provide: type,
     useFactory: function() {
-      return createSpyObject(type);
+      return createSpyObject(type, properties);
     }
   };
 }

--- a/src/app/consumer.service.spec.ts
+++ b/src/app/consumer.service.spec.ts
@@ -6,7 +6,11 @@ import { Subject } from 'rxjs';
 describe('ConsumerService', () => {
   const spectator = createService({
     service: ConsumerService,
-    providers: [mockProvider(ProviderService)]
+    providers: [
+      mockProvider(ProviderService, {
+        obs$: new Subject()
+      })
+    ]
   });
 
   it('should consume mocked service with properties', () => {

--- a/src/app/consumer.service.spec.ts
+++ b/src/app/consumer.service.spec.ts
@@ -1,0 +1,18 @@
+import { ConsumerService } from './consumer.service';
+import { createService, mockProvider } from '@netbasal/spectator';
+import { ProviderService } from './provider.service';
+import { Subject } from 'rxjs';
+
+describe('ConsumerService', () => {
+  const spectator = createService({
+    service: ConsumerService,
+    providers: [mockProvider(ProviderService)]
+  });
+
+  it('should consume mocked service with properties', () => {
+    const provider = spectator.get<ProviderService>(ProviderService);
+    expect(spectator.service.lastValue).toBeUndefined();
+    provider.obs$.next('hey you');
+    expect(spectator.service.lastValue).toBe('hey you');
+  });
+});

--- a/src/app/consumer.service.ts
+++ b/src/app/consumer.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { ProviderService } from './provider.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConsumerService {
+  lastValue: any;
+
+  constructor(provider: ProviderService) {
+    provider.obs$.subscribe(val => this.update(val));
+  }
+
+  update(val: string) {
+    this.lastValue = val;
+  }
+}

--- a/src/app/provider.service.ts
+++ b/src/app/provider.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProviderService {
+  obs$ = new Subject<string>();
+  constructor() {}
+}


### PR DESCRIPTION
Solves https://github.com/NetanelBasal/spectator/issues/56

First commit shows the problem.

The second commit adds optional argument for `mockProvider` representing a kind of template for a mock. It's supposed to be an object with subset of properties from the mocked service.