### PR TITLE
docs(mock-component): deprecate MockComponent

### DIFF
--- a/projects/spectator/src/lib/mock-component.ts
+++ b/projects/spectator/src/lib/mock-component.ts
@@ -5,6 +5,7 @@ import { Component, EventEmitter, Type } from '@angular/core';
  * MockComponent({ selector: 'some-component' });
  * MockComponent({ selector: 'some-component', inputs: ['some-input', 'some-other-input'] });
  *
+ * @deprecated Deprecated in favour of the `ng-mocks` implementation of `MockComponent`. To be be removed in the next major version.
  */
 export function MockComponent(options: Component & { identifier?: Type<any> }): Component {
   const metadata: Component & { identifier?: Type<any> } = {


### PR DESCRIPTION
Addresses issue #59.