### PR TITLE
test(jest): add Jest specs matching all the Jasmine specs that have Spectator imports

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -76,6 +76,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "LayZeeDK",
+      "name": "Lars Gyrup Brink Nielsen",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/6364586?v=4",
+      "profile": "https://medium.com/@LayZeeDK",
+      "contributions": [
+        "platform",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![Downloads](https://img.shields.io/npm/dt/@netbasal/spectator.svg?style=flat-square)]()
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 [![spectator](https://img.shields.io/badge/tested%20with-spectator-2196F3.svg?style=flat-square)]()
 [![MIT](https://img.shields.io/packagist/l/doctrine/orm.svg?style=flat-square)]()
 [![commitizen](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat-square)]()
@@ -106,6 +106,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 <!-- prettier-ignore -->
 | [<img src="https://avatars3.githubusercontent.com/u/638818?v=4" width="100px;"/><br /><sub><b>I. Sinai</b></sub>](https://github.com/theblushingcrow)<br />[📖](https://github.com/NetanelBasal/spectator/commits?author=theblushingcrow "Documentation") [👀](#review-theblushingcrow "Reviewed Pull Requests") [🎨](#design-theblushingcrow "Design") | [<img src="https://avatars3.githubusercontent.com/u/18645670?v=4" width="100px;"/><br /><sub><b>Valentin Buryakov</b></sub>](https://github.com/valburyakov)<br />[💻](https://github.com/NetanelBasal/spectator/commits?author=valburyakov "Code") [🤔](#ideas-valburyakov "Ideas, Planning, & Feedback") | [<img src="https://avatars1.githubusercontent.com/u/6745730?v=4" width="100px;"/><br /><sub><b>Netanel Basal</b></sub>](https://www.netbasal.com)<br />[💻](https://github.com/NetanelBasal/spectator/commits?author=NetanelBasal "Code") [🔧](#tool-NetanelBasal "Tools") | [<img src="https://avatars1.githubusercontent.com/u/260431?v=4" width="100px;"/><br /><sub><b>Ben Grynhaus</b></sub>](https://github.com/bengry)<br />[🐛](https://github.com/NetanelBasal/spectator/issues?q=author%3Abengry "Bug reports") [💻](https://github.com/NetanelBasal/spectator/commits?author=bengry "Code") | [<img src="https://avatars1.githubusercontent.com/u/4996462?v=4" width="100px;"/><br /><sub><b>Ben Elliott</b></sub>](http://benjaminelliott.co.uk)<br />[💻](https://github.com/NetanelBasal/spectator/commits?author=benelliott "Code") | [<img src="https://avatars2.githubusercontent.com/u/681176?v=4" width="100px;"/><br /><sub><b>Martin Nuc</b></sub>](http://www.nuc.cz)<br />[💻](https://github.com/NetanelBasal/spectator/commits?author=MartinNuc "Code") | [<img src="https://avatars2.githubusercontent.com/u/2102973?v=4" width="100px;"/><br /><sub><b>Dirk Luijk</b></sub>](https://github.com/dirkluijk)<br />[💻](https://github.com/NetanelBasal/spectator/commits?author=dirkluijk "Code") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars1.githubusercontent.com/u/6364586?v=4" width="100px;"/><br /><sub><b>Lars Gyrup Brink Nielsen</b></sub>](https://medium.com/@LayZeeDK)<br />[📦](#platform-LayZeeDK "Packaging/porting to new platform") [⚠️](https://github.com/NetanelBasal/spectator/commits?author=LayZeeDK "Tests") |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/src/app/async-input/async-input.component.jest.ts
+++ b/src/app/async-input/async-input.component.jest.ts
@@ -1,0 +1,29 @@
+import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator/jest';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { AsyncInputComponent } from './async-input.component';
+
+describe('ZippyComponent', () => {
+  let host: SpectatorWithHost<AsyncInputComponent>;
+
+  const createHost = createHostComponentFactory(AsyncInputComponent);
+
+  it('should work', () => {
+    const { component } = createHost(`<app-async-input></app-async-input>`);
+    expect(component).toBeDefined();
+  });
+
+  it('should not be visible', () => {
+    host = createHost(`<app-async-input></app-async-input>`);
+    host.setInput('widgets', '');
+    expect(host.query('div')).not.toExist();
+  });
+
+  it('should be visible', fakeAsync(() => {
+    host = createHost(`<app-async-input></app-async-input>`, true, {
+      widgets: ''
+    });
+    tick();
+    host.detectChanges();
+    expect(host.query('div')).toExist();
+  }));
+});

--- a/src/app/async/async.component.jest.ts
+++ b/src/app/async/async.component.jest.ts
@@ -1,0 +1,31 @@
+import { of } from 'rxjs';
+import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator/jest';
+import { QueryService } from '../query.service';
+import { AsyncComponent } from './async.component';
+
+describe('ZippyComponent', () => {
+  let host: SpectatorWithHost<AsyncComponent>;
+
+  const createHost = createHostComponentFactory({
+    component: AsyncComponent,
+    mocks: [QueryService]
+  });
+
+  it('should work', () => {
+    const { component } = createHost(`<app-async></app-async>`);
+    expect(component).toBeDefined();
+  });
+
+  it('should be falsy', () => {
+    host = createHost(`<app-async></app-async>`);
+    expect(host.query('p')).not.toExist();
+  });
+
+  it('should be truthy', () => {
+    const host = createHost(`<app-async></app-async>`, false);
+    let queryService = host.get<QueryService>(QueryService);
+    queryService.select.mockReturnValue(of(true));
+    host.detectChanges();
+    expect(host.query('p')).toExist();
+  });
+});

--- a/src/app/button/button.component.jest.ts
+++ b/src/app/button/button.component.jest.ts
@@ -1,0 +1,65 @@
+import { createTestComponentFactory, Spectator } from '@netbasal/spectator/jest';
+import { QueryService } from '../query.service';
+import { ButtonComponent } from './button.component';
+import { mockProvider } from '../../../projects/spectator/src/lib/mock';
+import { of } from 'rxjs';
+
+describe('ButtonComponent', () => {
+  let spectator: Spectator<ButtonComponent>;
+
+  const createComponent = createTestComponentFactory<ButtonComponent>({
+    component: ButtonComponent,
+    componentProviders: [mockProvider(QueryService)]
+  });
+
+  beforeEach(() => (spectator = createComponent()));
+
+  it('should set the "success" class by default', () => {
+    expect(spectator.query('button')).toHaveClass('success');
+  });
+
+  it('should set the class name according to the [className]', () => {
+    spectator.setInput('className', 'danger');
+    expect(spectator.query('button')).toHaveClass('danger');
+    expect(spectator.query('button')).not.toHaveClass('success');
+  });
+
+  it('should set the title according to the [title]', () => {
+    spectator = createComponent({ title: 'Click' });
+
+    expect(spectator.query('button')).toHaveText('Click');
+  });
+
+  it('should emit the $event on click', () => {
+    let output;
+    spectator.output<{ type: string }>('click').subscribe(result => (output = result));
+
+    spectator.component.onClick({ type: 'click' });
+    expect(output).toEqual({ type: 'click' });
+  });
+
+  it('should mock the service', () => {
+    spectator = createComponent({}, false);
+    spectator.get<QueryService>(QueryService, true).selectName.and.returnValue(of('Netanel'));
+    spectator.detectChanges();
+    expect(spectator.query('p')).toHaveText('Netanel');
+  });
+});
+
+describe('ButtonComponent', () => {
+  let spectator: Spectator<ButtonComponent>;
+
+  const createComponent = createTestComponentFactory<ButtonComponent>({
+    component: ButtonComponent,
+    providers: [mockProvider(QueryService)],
+    detectChanges: false
+  });
+
+  beforeEach(() => (spectator = createComponent()));
+
+  it('should not run cd by default', () => {
+    expect(spectator.query('button')).not.toHaveClass('success');
+    spectator.detectChanges();
+    expect(spectator.query('button')).toHaveClass('success');
+  });
+});

--- a/src/app/calc/calc.component.jest.ts
+++ b/src/app/calc/calc.component.jest.ts
@@ -1,0 +1,22 @@
+import { createTestComponentFactory, Spectator } from '@netbasal/spectator/jest';
+import { CalcComponent } from './calc.component';
+
+describe('CalcComponent', () => {
+  let spectator: Spectator<CalcComponent>;
+  const createComponent = createTestComponentFactory(CalcComponent);
+
+  it('should be defined', () => {
+    spectator = createComponent();
+    expect(spectator.component).toBeTruthy();
+  });
+
+  it('should calc the value', () => {
+    spectator = createComponent();
+    const a = spectator.query('.a') as HTMLInputElement;
+    const b = spectator.query('.b') as HTMLInputElement;
+    spectator.typeInElement('1', a);
+    spectator.typeInElement('2', b);
+
+    expect(spectator.query('.result')).toHaveText('12');
+  });
+});

--- a/src/app/consum-dynamic/consume-dynamic.component.jest.ts
+++ b/src/app/consum-dynamic/consume-dynamic.component.jest.ts
@@ -1,0 +1,23 @@
+import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator/jest';
+import { DynamicComponent } from '../dynamic/dynamic.component';
+import { ConsumeDynamicComponent } from './consume-dynamic.component';
+
+describe('ConsumeDynamicComponent', () => {
+  let host: SpectatorWithHost<ConsumeDynamicComponent>;
+
+  const createHost = createHostComponentFactory({
+    declarations: [DynamicComponent],
+    entryComponents: [DynamicComponent],
+    component: ConsumeDynamicComponent
+  });
+
+  it('should work', () => {
+    host = createHost(`<app-consume-dynamic></app-consume-dynamic>`);
+    expect(host.component).toBeDefined();
+  });
+
+  it('should render the dynamic component', function() {
+    host = createHost(`<app-consume-dynamic></app-consume-dynamic>`);
+    expect(host.queryHost('.dynamic')).toHaveText('dynamic works!');
+  });
+});

--- a/src/app/consumer.service.jest.ts
+++ b/src/app/consumer.service.jest.ts
@@ -1,0 +1,22 @@
+import { ConsumerService } from './consumer.service';
+import { createService, mockProvider } from '@netbasal/spectator/jest';
+import { ProviderService } from './provider.service';
+import { Subject } from 'rxjs';
+
+describe('ConsumerService', () => {
+  const spectator = createService({
+    service: ConsumerService,
+    providers: [
+      mockProvider(ProviderService, {
+        obs$: new Subject()
+      })
+    ]
+  });
+
+  it('should consume mocked service with properties', () => {
+    const provider = spectator.get<ProviderService>(ProviderService);
+    expect(spectator.service.lastValue).toBeUndefined();
+    provider.obs$.next('hey you');
+    expect(spectator.service.lastValue).toBe('hey you');
+  });
+});

--- a/src/app/dom-selectors/dom-selectors.component.jest.ts
+++ b/src/app/dom-selectors/dom-selectors.component.jest.ts
@@ -1,0 +1,42 @@
+import { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue } from '@netbasal/spectator';
+import { createTestComponentFactory, Spectator } from '@netbasal/spectator/jest';
+import { DomSelectorsComponent } from './dom-selectors.component';
+
+describe('DomSelectorsComponent', () => {
+  let spectator: Spectator<DomSelectorsComponent>;
+  const createComponent = createTestComponentFactory(DomSelectorsComponent);
+
+  beforeEach(() => {
+    spectator = createComponent();
+  });
+
+  it('should allow querying by text', () => {
+    const element = spectator.query(byText('By text'));
+    expect(element).toHaveId('by-text-p');
+  });
+
+  it('should allow querying by label', () => {
+    const element = spectator.query(byLabel('By label'));
+    expect(element).toHaveId('by-label-input');
+  });
+
+  it('should allow querying by placeholder', () => {
+    const element = spectator.query(byPlaceholder('By placeholder'));
+    expect(element).toHaveId('by-placeholder-input');
+  });
+
+  it('should allow querying by alt text', () => {
+    const element = spectator.query(byAltText('By alt text'));
+    expect(element).toHaveId('by-alt-text-img');
+  });
+
+  it('should allow querying by title', () => {
+    const element = spectator.query(byTitle('By title'));
+    expect(element).toHaveId('by-title-a');
+  });
+
+  it('should allow querying by value', () => {
+    const element = spectator.query(byValue('By value'));
+    expect(element).toHaveId('by-value-input');
+  });
+});

--- a/src/app/fg/fg.component.jest.ts
+++ b/src/app/fg/fg.component.jest.ts
@@ -1,0 +1,26 @@
+import { SpectatorWithHost, createHostComponentFactory } from '@netbasal/spectator/jest';
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FgComponent } from './fg.component';
+
+@Component({ selector: 'app-custom-host', template: '' })
+class CustomHostComponent {
+  group = new FormGroup({
+    name: new FormControl('name')
+  });
+}
+
+describe('With Custom Host Component', function() {
+  let host: SpectatorWithHost<FgComponent, CustomHostComponent>;
+
+  const createHost = createHostComponentFactory({
+    component: FgComponent,
+    imports: [ReactiveFormsModule],
+    host: CustomHostComponent
+  });
+
+  it('should display the host component title', () => {
+    host = createHost(`<app-fg [group]="group"></app-fg>`);
+    expect(host.component).toBeDefined();
+  });
+});

--- a/src/app/form-input/form-input.component.jest.ts
+++ b/src/app/form-input/form-input.component.jest.ts
@@ -1,0 +1,48 @@
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormInputComponent } from './form-input.component';
+import { createHostComponentFactory, SpectatorWithHost, Spectator, createTestComponentFactory } from '@netbasal/spectator/jest';
+
+describe('FormInputComponent', () => {
+  let host: SpectatorWithHost<FormInputComponent>;
+  const createHost = createHostComponentFactory({
+    component: FormInputComponent,
+    imports: [ReactiveFormsModule]
+  });
+  const group = new FormGroup({ name: new FormControl('') });
+
+  const inputs = {
+    subnetControl: group
+  };
+
+  it('should be defined', () => {
+    host = createHost(`<app-form-input [enableSubnet]="true"></app-form-input>`, true, inputs);
+    expect(host.component).toBeDefined();
+    expect(host.query('p')).not.toBeNull();
+    host.setInput('enableSubnet', false);
+    expect(host.query('p')).toBeNull();
+  });
+});
+
+describe('FormInputComponent', () => {
+  let spectator: Spectator<FormInputComponent>;
+  const group = new FormGroup({ name: new FormControl('') });
+
+  const inputs = {
+    subnetControl: group,
+    enableSubnet: true
+  };
+
+  const createComponent = createTestComponentFactory<FormInputComponent>({
+    component: FormInputComponent,
+    imports: [ReactiveFormsModule]
+  });
+
+  beforeEach(() => (spectator = createComponent(inputs)));
+
+  it('should work', () => {
+    expect(spectator.component).toBeDefined();
+    expect(spectator.query('p')).not.toBeNull();
+    spectator.setInput('enableSubnet', false);
+    expect(spectator.query('p')).toBeNull();
+  });
+});

--- a/src/app/hello/hello.component.jest.ts
+++ b/src/app/hello/hello.component.jest.ts
@@ -1,0 +1,23 @@
+import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator/jest';
+import { HelloComponent } from './hello.component';
+
+describe('HelloComponent', () => {
+  let host: SpectatorWithHost<HelloComponent>;
+
+  const createHost = createHostComponentFactory(HelloComponent);
+
+  it('should display the title', () => {
+    host = createHost(
+      `
+      <hello></hello>
+    `,
+      true,
+      {
+        title: 'some title',
+        widthRaw: 20
+      }
+    );
+
+    expect((host.query('div') as HTMLElement).style.width).toBe('20px');
+  });
+});

--- a/src/app/no-overwritten-providers/no-overwritten-providers.component.jest.ts
+++ b/src/app/no-overwritten-providers/no-overwritten-providers.component.jest.ts
@@ -1,0 +1,34 @@
+import { createHostComponentFactory } from '@netbasal/spectator/jest';
+import { ComponentWithoutOverwrittenProvidersComponent } from './no-overwritten-providers.component';
+
+describe('ComponentWithoutOverwrittenProvidersComponent', () => {
+  describe('with options', () => {
+    let createHost = createHostComponentFactory({
+      component: ComponentWithoutOverwrittenProvidersComponent
+    });
+
+    it("should not overwrite component's providers and work using createHostComponentFactory", () => {
+      const { component } = createHost(`
+        <app-component-without-overwritten-providers>
+        </app-component-without-overwritten-providers>
+      `);
+
+      expect(component).toBeDefined();
+      expect(component.dummy).toBeDefined();
+    });
+  });
+
+  describe('with component', () => {
+    let createHost = createHostComponentFactory(ComponentWithoutOverwrittenProvidersComponent);
+
+    it("should not overwrite component's providers and work using createHostComponentFactory", () => {
+      const { component } = createHost(`
+        <app-component-without-overwritten-providers>
+        </app-component-without-overwritten-providers>
+      `);
+
+      expect(component).toBeDefined();
+      expect(component.dummy).toBeDefined();
+    });
+  });
+});

--- a/src/app/unless/unless.component.jest.ts
+++ b/src/app/unless/unless.component.jest.ts
@@ -1,0 +1,19 @@
+import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator/jest';
+
+import { AppUnlessDirective } from './unless.component';
+
+describe('HelloComponent', () => {
+  let host: SpectatorWithHost<AppUnlessDirective>;
+
+  const createHost = createHostComponentFactory(AppUnlessDirective);
+
+  it('should work', () => {
+    host = createHost(`<div *appUnless="false">Hello world</div>`);
+    expect(host.hostElement).toHaveText('Hello world');
+  });
+
+  it('should work', () => {
+    host = createHost(`<div *appUnless="true">Hello world</div>`);
+    expect(host.hostElement).not.toHaveText('Hello world');
+  });
+});

--- a/src/app/view-children/view-children.component.jest.ts
+++ b/src/app/view-children/view-children.component.jest.ts
@@ -1,0 +1,64 @@
+import { ElementRef } from '@angular/core';
+import { createHostComponentFactory, createTestComponentFactory, Spectator, SpectatorWithHost } from '@netbasal/spectator/jest';
+import { ChildServiceService } from '../child-service.service';
+import { ChildComponent } from '../child/child.component';
+import { ViewChildrenComponent } from './view-children.component';
+
+describe('ViewChildrenComponent', () => {
+  let spectator: Spectator<ViewChildrenComponent>;
+  const createComponent = createTestComponentFactory({
+    component: ViewChildrenComponent,
+    providers: [ChildServiceService],
+    declarations: [ChildComponent]
+  });
+
+  it('should exist', () => {
+    spectator = createComponent();
+    expect(spectator.component).toBeDefined();
+  });
+
+  it('should expose the view child', () => {
+    const serviceFromChild = spectator.query<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const div = spectator.query('div');
+    const component = spectator.query<ChildComponent>(ChildComponent);
+    const { nativeElement } = spectator.query<ElementRef>(ChildComponent, {
+      read: ElementRef
+    });
+    const button = spectator.query('button');
+
+    expect(serviceFromChild).toBeDefined();
+    expect(component).toBeDefined();
+    expect(div).toExist();
+  });
+
+  it('should expose the view children', () => {
+    const serviceFromChild = spectator.queryAll<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const divs = spectator.queryAll('div');
+    const components = spectator.queryAll<ChildComponent>(ChildComponent);
+    expect(serviceFromChild.length).toBe(4);
+    expect(components.length).toBe(4);
+    expect(divs.length).toBe(2);
+  });
+});
+
+describe('ContentChild', () => {
+  let host: SpectatorWithHost<ViewChildrenComponent>;
+
+  const createHost = createHostComponentFactory({
+    component: ViewChildrenComponent,
+    providers: [ChildServiceService],
+    declarations: [ChildComponent]
+  });
+
+  it('should get also the content childs', () => {
+    host = createHost(`
+       <app-view-children>
+         <app-child></app-child>
+         <app-child></app-child>
+      </app-view-children>
+    `);
+
+    const contentChilds = host.queryAll<ChildComponent>(ChildComponent);
+    expect(contentChilds.length).toBe(6);
+  });
+});

--- a/src/app/widget/widget.component.jest.ts
+++ b/src/app/widget/widget.component.jest.ts
@@ -1,0 +1,24 @@
+import { createHostComponentFactory, SpectatorWithHost, SpyObject } from '@netbasal/spectator/jest';
+import { WidgetService } from '../widget.service';
+import { WidgetComponent } from './widget.component';
+
+describe('WidgetComponent', () => {
+  let host: SpectatorWithHost<WidgetComponent>;
+
+  const createHost = createHostComponentFactory<WidgetComponent>({
+    component: WidgetComponent,
+    mocks: [WidgetService]
+  });
+
+  it('should work', () => {
+    host = createHost(`<app-widget></app-widget>`);
+    expect(host.component).toBeDefined();
+  });
+
+  it('should call the service method on button click', () => {
+    host = createHost(`<app-widget></app-widget>`);
+    host.click('button');
+    const widgetService = host.component.widgetService as SpyObject<WidgetService>;
+    expect(widgetService.get).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add Jest specs to exercise as much of the API as the Jasmine specs do.

I discovered that the DOM selectors have not been exposed in Spectator's Jest API.