### PR TITLE
fix(jest): fix type collisions between jasmine/jest

### DIFF
--- a/projects/spectator/jest/src/matchers-types.d.ts
+++ b/projects/spectator/jest/src/matchers-types.d.ts
@@ -1,5 +1,5 @@
-declare namespace jasmine {
-  interface Matchers<T> {
+declare namespace jest {
+  interface Matchers<R> {
     toExist(): boolean;
 
     toHaveLength(expected: number): boolean;

--- a/projects/spectator/jest/src/public_api.ts
+++ b/projects/spectator/jest/src/public_api.ts
@@ -1,3 +1,4 @@
+/// <reference path="./matchers-types.d.ts" />
 export * from './config';
 export * from './host';
 export * from './http';

--- a/projects/spectator/tsconfig.lib.json
+++ b/projects/spectator/tsconfig.lib.json
@@ -11,9 +11,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "types": [
-      "@types/jest"
-    ],
+    "typeRoots" : ["./typings"],
+    "types": ["jasmine", "jest"],
     "lib": [
       "dom",
       "es2018"

--- a/projects/spectator/typings/jest/index.d.ts
+++ b/projects/spectator/typings/jest/index.d.ts
@@ -1,0 +1,23 @@
+/**
+ * This file was creating to avoid conflicts during building between jasmine and jest.
+ *
+ * Projects using @netbasal/spectator should just use either @types/jasmine or @types/jest.
+ */
+
+declare namespace jest {
+  interface Mock<T = {}> extends Function, MockInstance<T> {
+    new (...args: any[]): T;
+
+    (...args: any[]): any;
+  }
+
+  function fn<T>(implementation?: (...args: any[]) => any): Mock<T>;
+
+  interface MockInstance<T> {
+    mockImplementation(fn?: (...args: any[]) => any): Mock<T>;
+
+    mockReturnValue(value: any): Mock<T>;
+
+    mockReset(): void;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/NetanelBasal/spectator/issues/63. Tested on an initial Angular CLI project with Jasmine, and on an existing project with Jest.