### PR TITLE
Make queries work for directives

### DIFF
--- a/projects/spectator/src/lib/internals.ts
+++ b/projects/spectator/src/lib/internals.ts
@@ -27,9 +27,16 @@ const KEY_UP = 'keyup';
 
 export class Spectator<C> {
   fixture: ComponentFixture<C>;
-  debugElement: DebugElement;
   component: C;
   element: HTMLElement | Node | any;
+
+  private _debugElement: DebugElement;
+  get debugElement() {
+    return this._debugElement || this['hostDebugElement'];
+  }
+  set debugElement(value) {
+    this._debugElement = value;
+  }
 
   /**
    * Wrapper for TestBed.get()

--- a/src/app/unless/unless.component.jest.ts
+++ b/src/app/unless/unless.component.jest.ts
@@ -16,4 +16,9 @@ describe('HelloComponent', () => {
     host = createHost(`<div *appUnless="true">Hello world</div>`);
     expect(host.hostElement).not.toHaveText('Hello world');
   });
+
+  it('should use hostElement when using query to find element', () => {
+    host = createHost(`<div *appUnless="true">Hello world</div>`);
+    expect(host.query('div')).not.toHaveText('Hello world');
+  });
 });

--- a/src/app/unless/unless.component.spec.ts
+++ b/src/app/unless/unless.component.spec.ts
@@ -16,4 +16,9 @@ describe('HelloComponent', () => {
     host = createHost(`<div *appUnless="true">Hello world</div>`);
     expect(host.hostElement).not.toHaveText('Hello world');
   });
+
+  it('should use hostElement when using query to find element', () => {
+    host = createHost(`<div *appUnless="true">Hello world</div>`);
+    expect(host.query('div')).not.toHaveText('Hello world');
+  });
 });


### PR DESCRIPTION
This solves https://github.com/NetanelBasal/spectator/issues/66 where `query` would fail for a directive because it doesn't have a `debugElement`.

Fix is to use `hostDebugElement` when `debugElement` is not set.