### PR TITLE
feat(config): add declareComponent option

### DIFF
--- a/projects/spectator/src/lib/config.ts
+++ b/projects/spectator/src/lib/config.ts
@@ -26,6 +26,7 @@ export type SpectatorOptions<T = any, H = HostComponent> = TestModuleMetadata & 
   componentProviders?: any[];
   mocks?: Type<any>[];
   detectChanges?: boolean;
+  declareComponent?: boolean;
 };
 
 const defaultOptions: SpectatorOptions<any, any> = {
@@ -33,7 +34,8 @@ const defaultOptions: SpectatorOptions<any, any> = {
   shallow: false,
   host: HostComponent,
   entryComponents: [],
-  mocks: []
+  mocks: [],
+  declareComponent: true
 };
 
 export function initialModule<T, C = HostComponent>(
@@ -60,7 +62,7 @@ export function initialModule<T, C = HostComponent>(
       entryComponents: []
     };
   } else {
-    component = merged.component;
+    component = merged.declareComponent ? merged.component : [];
     host = merged.host;
 
     moduleMetadata = {

--- a/projects/spectator/src/lib/config.ts
+++ b/projects/spectator/src/lib/config.ts
@@ -62,11 +62,11 @@ export function initialModule<T, C = HostComponent>(
       entryComponents: []
     };
   } else {
-    component = merged.declareComponent ? merged.component : [];
+    component = merged.component;
     host = merged.host;
 
     moduleMetadata = {
-      declarations: [component, withHost ? host : [], ...(merged.declarations || [])],
+      declarations: [merged.declareComponent ? component : [], withHost ? host : [], ...(merged.declarations || [])],
       imports: [merged.disableAnimations ? NoopAnimationsModule : [], ...(merged.imports || [])],
       schemas: [merged.shallow ? NO_ERRORS_SCHEMA : []],
       providers: [...(merged.providers || [])],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,11 +26,12 @@ import { WidgetService } from './widget.service';
 import { WidgetComponent } from './widget/widget.component';
 import { ZippyComponent } from './zippy/zippy.component';
 import { FormInputComponent } from './form-input/form-input.component';
+import { IntegrationModule } from './integration/integration.module';
 
 @NgModule({
   declarations: [AppComponent, ZippyComponent, ButtonComponent, HighlightDirective, CalcComponent, DynamicComponent, ConsumeDynamicComponent, ViewChildrenComponent, ChildComponent, WidgetComponent, AppUnlessDirective, WidgetComponent, ClickComponent, AutoFocusDirective, FgComponent, AsyncComponent, DomSelectorsComponent, HelloComponent, AsyncInputComponent, ComponentWithoutOverwrittenProvidersComponent, FormInputComponent],
   entryComponents: [DynamicComponent],
-  imports: [BrowserModule, HttpClientModule, ReactiveFormsModule],
+  imports: [BrowserModule, HttpClientModule, ReactiveFormsModule, IntegrationModule],
   providers: [ChildServiceService, WidgetService, WidgetDataService],
   bootstrap: [AppComponent]
 })

--- a/src/app/integration/integration-child.component.ts
+++ b/src/app/integration/integration-child.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-integration-child',
+  template: `
+    <p>
+      integration-child works!
+    </p>
+  `,
+  styles: []
+})
+export class IntegrationChildComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/integration/integration-parent.component.spec.ts
+++ b/src/app/integration/integration-parent.component.spec.ts
@@ -1,0 +1,20 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IntegrationParentComponent } from './integration-parent.component';
+import { Spectator, createTestComponentFactory } from '@netbasal/spectator';
+import { IntegrationModule } from './integration.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('IntegrationParentComponent', () => {
+  let spectator: Spectator<IntegrationParentComponent>;
+  const createComponent = createTestComponentFactory({
+    component: IntegrationParentComponent,
+    imports: [IntegrationModule, HttpClientTestingModule],
+    declareComponent: false
+  });
+
+  it('should exist', () => {
+    spectator = createComponent();
+    expect(spectator.component).toBeDefined();
+  });
+});

--- a/src/app/integration/integration-parent.component.ts
+++ b/src/app/integration/integration-parent.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+import { WidgetService } from '../widget.service';
+
+@Component({
+  selector: 'app-integration-parent',
+  template: `
+    <app-integration-child></app-integration-child>
+  `,
+  styles: []
+})
+export class IntegrationParentComponent implements OnInit {
+  constructor(public widgetService: WidgetService) {}
+
+  ngOnInit() {}
+}

--- a/src/app/integration/integration.module.ts
+++ b/src/app/integration/integration.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IntegrationParentComponent } from './integration-parent.component';
+import { IntegrationChildComponent } from './integration-child.component';
+import { WidgetService } from '../widget.service';
+import { WidgetDataService } from '../widget-data.service';
+
+@NgModule({
+  imports: [CommonModule],
+  providers: [WidgetService, WidgetDataService],
+  declarations: [IntegrationParentComponent, IntegrationChildComponent],
+  exports: [IntegrationParentComponent]
+})
+export class IntegrationModule {}


### PR DESCRIPTION
I suggest to introduce a `declareComponent` option to the SpectatorOptions, usecase would be if the component i want to test is already declared in a module together with it's dependecies. This benefits the reusability of already existing modules and simplifies setting up tests for components. Example:

```
@NgModule({
  declarations:[TheComponent, SubComponent],
  exports:[TheComponent],
  imports: [SomeModule, AnotherModule]
})
export class TheComponentModule {}
```

With `declareComponent` option:

```
const createHost = createHostComponentFactory({
    component: TheComponent,
    imports: [TheComponentModule],
    declareComponent: false
});
```

Without `declareComponent` option:

```
const createHost = createHostComponentFactory({
    component: TheComponent,
    declarations:[SubComponent],
    imports: [SomeModule, AnotherModule]
});
```