### PR TITLE
Avoid spec has no expectations when using expectOne

### DIFF
--- a/projects/spectator/src/lib/http.ts
+++ b/projects/spectator/src/lib/http.ts
@@ -49,6 +49,7 @@ export function createHTTPFactory<T>(dataService: Type<T>, providers = []): () =
     };
 
     http.expectOne = (url: string, method: HTTPMethod) => {
+      expect(true).toBe(true); // workaround to avoid `Spec has no expectations` https://github.com/NetanelBasal/spectator/issues/75
       const req = http.controller.expectOne({
         url,
         method


### PR DESCRIPTION
This implements workaround for https://github.com/NetanelBasal/spectator/issues/75

To see that error message I had to use newer version of karma/jasmine/karma-jasmine-html-reporter. After this change the message is no longer there.