### PR TITLE
Allow mockProvider to mock methods using 2nd argument

### DIFF
--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -24,7 +24,7 @@ export function installProtoMethods(mock: any, proto: any, createSpyFn: Function
   for (const key of Object.getOwnPropertyNames(proto)) {
     const descriptor = Object.getOwnPropertyDescriptor(proto, key);
 
-    if (typeof descriptor.value === 'function' && key !== 'constructor') {
+    if (typeof descriptor.value === 'function' && key !== 'constructor' && typeof mock[key] === 'undefined') {
       mock[key] = createSpyFn(key);
     }
   }

--- a/src/app/consumer.service.jest.ts
+++ b/src/app/consumer.service.jest.ts
@@ -4,11 +4,13 @@ import { ProviderService } from './provider.service';
 import { Subject } from 'rxjs';
 
 describe('ConsumerService', () => {
+  const randomNumber = Math.random();
   const spectator = createService({
     service: ConsumerService,
     providers: [
       mockProvider(ProviderService, {
-        obs$: new Subject()
+        obs$: new Subject(),
+        method: () => randomNumber
       })
     ]
   });
@@ -18,5 +20,9 @@ describe('ConsumerService', () => {
     expect(spectator.service.lastValue).toBeUndefined();
     provider.obs$.next('hey you');
     expect(spectator.service.lastValue).toBe('hey you');
+  });
+
+  it('should consume mocked service methods', () => {
+    expect(spectator.service.consumeProvider()).toBe(randomNumber);
   });
 });

--- a/src/app/consumer.service.spec.ts
+++ b/src/app/consumer.service.spec.ts
@@ -4,11 +4,13 @@ import { ProviderService } from './provider.service';
 import { Subject } from 'rxjs';
 
 describe('ConsumerService', () => {
+  const randomNumber = Math.random();
   const spectator = createService({
     service: ConsumerService,
     providers: [
       mockProvider(ProviderService, {
-        obs$: new Subject()
+        obs$: new Subject(),
+        method: () => randomNumber
       })
     ]
   });
@@ -18,5 +20,9 @@ describe('ConsumerService', () => {
     expect(spectator.service.lastValue).toBeUndefined();
     provider.obs$.next('hey you');
     expect(spectator.service.lastValue).toBe('hey you');
+  });
+
+  it('should consume mocked service methods', () => {
+    expect(spectator.service.consumeProvider()).toBe(randomNumber);
   });
 });

--- a/src/app/consumer.service.ts
+++ b/src/app/consumer.service.ts
@@ -7,11 +7,15 @@ import { ProviderService } from './provider.service';
 export class ConsumerService {
   lastValue: any;
 
-  constructor(provider: ProviderService) {
+  constructor(private provider: ProviderService) {
     provider.obs$.subscribe(val => this.update(val));
   }
 
   update(val: string) {
     this.lastValue = val;
+  }
+
+  consumeProvider() {
+    return this.provider.method();
   }
 }

--- a/src/app/provider.service.ts
+++ b/src/app/provider.service.ts
@@ -7,4 +7,8 @@ import { Subject } from 'rxjs';
 export class ProviderService {
   obs$ = new Subject<string>();
   constructor() {}
+
+  method() {
+    return 5;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/NetanelBasal/spectator/issues/88