### PR TITLE
fix(config): map schemas option to initial module config

### DIFF
--- a/projects/spectator/src/lib/config.ts
+++ b/projects/spectator/src/lib/config.ts
@@ -68,7 +68,7 @@ export function initialModule<T, C = HostComponent>(
     moduleMetadata = {
       declarations: [merged.declareComponent ? component : [], withHost ? host : [], ...(merged.declarations || [])],
       imports: [merged.disableAnimations ? NoopAnimationsModule : [], ...(merged.imports || [])],
-      schemas: [merged.shallow ? NO_ERRORS_SCHEMA : []],
+      schemas: [merged.shallow ? NO_ERRORS_SCHEMA : merged.schemas || []],
       providers: [...(merged.providers || [])],
       componentProviders: merged.componentProviders ? [merged.componentProviders] : undefined,
       entryComponents: [merged.entryComponents]


### PR DESCRIPTION
This allows to make unit tests for Angular components with web components, for which you might want to use `CUSTOM_ELEMENTS_SCHEMA` (instead of `NO_ERRORS_SCHEMA`).