### PR TITLE
fix(jest): fix for incorrect typing of SpyObject for Jest

### DIFF
--- a/projects/spectator/jest/src/mock.ts
+++ b/projects/spectator/jest/src/mock.ts
@@ -1,7 +1,7 @@
 import { Provider, Type } from '@angular/core';
 import { CompatibleSpy, SpyObject as BaseSpyObject, installProtoMethods } from '@netbasal/spectator';
 
-export type SpyObject<T> = BaseSpyObject<T> & { [P in keyof T]: T[P] & jest.Mock<T> };
+export type SpyObject<T> = BaseSpyObject<T> & { [P in keyof T]: T[P] & (T[P] extends (...args: any[]) => infer R ? jest.Mock<R> : T[P]) };
 
 export function createSpyObject<T>(type: Type<T>, template?: Partial<Record<keyof T, any>>): SpyObject<T> {
   const mock: any = template || {};

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -27,5 +27,8 @@
     "jquery": "3.3.1",
     "schematics-utilities": "^1.1.1"
   },
+  "peerDependencies": {
+    "typescript": ">= 2.8.0"
+  },
   "schematics": "./schematics/collection.json"
 }


### PR DESCRIPTION
Just upgraded to Jest 24, and got compiler errors. I think the reason this bug was nog blocking before, is that `@types/jest@24.0.0` is more strict with generics.

**The issue**
Given an interface:
```typescript
interface Person {
  name: string;
  saySomething: () => string;
}
```

when you define `SpyObject<Person>` as `{ [P in keyof Person]: Person[P] & jest.Mock<Person>`, then `personSpyObject.saySomething` would be a `() => string & jest.Mock<Person>`. That is wrong, because it should be a `jest.Mock<string>`.

To get the return type of `Person[P]` I use `ReturnType` combined with conditional types from Typescript 2.8. Awesome stuff by the way.
