### PR TITLE
Add exact text matcher support

### DIFF
--- a/projects/spectator/jest/src/matchers-types.d.ts
+++ b/projects/spectator/jest/src/matchers-types.d.ts
@@ -20,7 +20,9 @@ declare namespace jest {
 
     toHaveProperty(prop: string, val: string | boolean): boolean;
 
-    toHaveText(text: string | Function): boolean;
+    toHaveText(text: string | Function, exact?: boolean): boolean;
+
+    toHaveExactText(text: string | Function): boolean;
 
     toHaveValue(value: string): boolean;
 

--- a/projects/spectator/src/lib/matchers-types.d.ts
+++ b/projects/spectator/src/lib/matchers-types.d.ts
@@ -20,7 +20,9 @@ declare namespace jasmine {
 
     toHaveProperty(prop: string, val: string | boolean): boolean;
 
-    toHaveText(text: string | Function): boolean;
+    toHaveText(text: string | Function, exact?: boolean): boolean;
+
+    toHaveExactText(text: string | Function): boolean;
 
     toHaveValue(value: string): boolean;
 

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -52,6 +52,18 @@ const hasCss = (el, css) => {
   return true;
 };
 
+const hasSameText = (el, expected, exact = false) => {
+  const actual = exact ? $(el).text() : $.trim($(el).text());
+  if (expected && $.isFunction(expected)) {
+    const pass = expected(actual);
+    const message = () => `Expected element${pass ? ' not' : ''} to have ${exact ? 'exact' : ''} text matching '${expected}', but had '${actual}'`;
+    return { pass, message };
+  }
+  const pass = exact ? actual === expected : actual.indexOf(expected) !== -1;
+  const message = () => `Expected element${pass ? ' not' : ''} to have ${exact ? 'exact' : ''} text '${expected}', but had '${actual}'`;
+  return { pass, message };
+};
+
 /**
  *
  * @param func
@@ -157,17 +169,9 @@ export const toHaveProperty = comparator((el, prop, val) => {
  *
  * expect('.zippy__content').toHaveText((text) => text.includes('..');
  */
-export const toHaveText = comparator((el, expected) => {
-  const actual = $.trim($(el).text());
-  if (expected && $.isFunction(expected)) {
-    const pass = expected(actual);
-    const message = () => `Expected element${pass ? ' not' : ''} to have text matching '${expected}', but had '${actual}'`;
-    return { pass, message };
-  }
-  const pass = actual.indexOf(expected) !== -1;
-  const message = () => `Expected element${pass ? ' not' : ''} to have text '${expected}', but had '${actual}'`;
-  return { pass, message };
-});
+export const toHaveText = comparator((el, expected, exact = false) => hasSameText(el, expected, exact));
+
+export const toHaveExactText = comparator((el, expected) => hasSameText(el, expected, true));
 
 /**
  *

--- a/src/app/hello/hello.component.jest.ts
+++ b/src/app/hello/hello.component.jest.ts
@@ -19,5 +19,16 @@ describe('HelloComponent', () => {
     );
 
     expect((host.query('div') as HTMLElement).style.width).toBe('20px');
+
+    expect('div h1').toHaveText(''); // This should return true, according to the original code
+    expect('div h1').toHaveText('some title');
+    expect('div h1').toHaveText('ome title');
+
+    expect('div h1').toHaveText('some title', true);
+    expect('div h1').not.toHaveText('ome title', true);
+
+    expect('div h1').toHaveExactText('some title');
+    expect('div h1').not.toHaveExactText('ome title');
+    expect('div h1').not.toHaveExactText('');
   });
 });

--- a/src/app/hello/hello.component.spec.ts
+++ b/src/app/hello/hello.component.spec.ts
@@ -19,5 +19,16 @@ describe('HelloComponent', () => {
     );
 
     expect((host.query('div') as HTMLElement).style.width).toBe('20px');
+
+    expect('div h1').toHaveText(''); // This should return true, according to the original code
+    expect('div h1').toHaveText('some title');
+    expect('div h1').toHaveText('ome title');
+
+    expect('div h1').toHaveText('some title', true);
+    expect('div h1').not.toHaveText('ome title', true);
+
+    expect('div h1').toHaveExactText('some title');
+    expect('div h1').not.toHaveExactText('ome title');
+    expect('div h1').not.toHaveExactText('');
   });
 });


### PR DESCRIPTION
During our daily work, we discovered that the toHaveText matcher is not accurate for exact matches. For instance, you can have this line of code:

`expect('foo').toHaveText('bar'); // true`

This is true, of course. However, this is true as well:

`expect('foo').toHaveText(''); // true`
`expect('foo').toHaveText('ar'); // true`

In order to have an exact text matcher, I have added the toHaveExactText matcher. It works as follows:

`expect('foo').toHaveExactText('bar'); // true`
`expect('foo').toHaveExactText('ar'); // false`

Furthermore, one can call the exact matcher by adding an additional property to the original matcher as well:

`expect('foo').toHaveText('ar', false); // true`
`expect('foo').toHaveText('ar', true); // false`

What do you guys think of this? Please, feel free to change the code in this PR if you believe your change fits better.