### PR TITLE
fix(matchers): pass input to `isHidden` through jQuery (fixes #122)

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -247,7 +247,9 @@ export const toBeEmpty = comparator(el => {
  * 4. Type equal to "hidden" (only for form elements)
  * 5. A "hidden" attribute
  */
-function isHidden(el) {
+function isHidden(elOrSelector) {
+  let el = $(elOrSelector);
+
   while (el) {
     if (el === document) {
       break;


### PR DESCRIPTION
Ensures the matcher logic operates on an element even if a selector is provided as input to the function.