### PR TITLE
fix(spectator): improve type inference for Spectator

### DIFF
--- a/projects/spectator/jest/src/service.ts
+++ b/projects/spectator/jest/src/service.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://github.com/NetanelBasal/spectator/blob/master/LICENSE
  */
 
-import { Type } from '@angular/core';
+import { InjectionToken, Type } from '@angular/core';
 import { SpectatorService as BaseSpectatorService, createService as baseCreateService, isType, ServiceParams } from '@netbasal/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 
 export interface SpectatorService<S> extends BaseSpectatorService<S> {
-  get<T>(token: any): T & SpyObject<T>;
+  get<T>(token: Type<T> | InjectionToken<T>): T & SpyObject<T>;
 }
 
 export function createService<S>(options: ServiceParams<S> | Type<S>): SpectatorService<S> {

--- a/projects/spectator/src/lib/config.ts
+++ b/projects/spectator/src/lib/config.ts
@@ -30,7 +30,7 @@ export type SpectatorOptions<T = any, H = HostComponent> = TestModuleMetadata & 
   declareComponent?: boolean;
 };
 
-const defaultOptions: SpectatorOptions<any, any> = {
+const defaultOptions: SpectatorOptions<any, HostComponent> = {
   disableAnimations: true,
   shallow: false,
   host: HostComponent,

--- a/projects/spectator/src/lib/host.ts
+++ b/projects/spectator/src/lib/host.ts
@@ -68,9 +68,9 @@ export class SpectatorWithHost<C, H = HostComponent> extends Spectator<C> {
     this.hostFixture.detectChanges();
   }
 
-  getDirectiveInstance<T>(directive: Type<any>, all?: false): T;
-  getDirectiveInstance<T>(directive: Type<any>, all?: true): T[];
-  getDirectiveInstance<T>(directive: Type<any>, all = false): T | T[] {
+  getDirectiveInstance<T>(directive: Type<T>, all?: false): T;
+  getDirectiveInstance<T>(directive: Type<T>, all?: true): T[];
+  getDirectiveInstance<T>(directive: Type<T>, all = false): T | T[] {
     if (all) {
       return this.hostFixture.debugElement.queryAll(By.directive(directive)).map(d => d.injector.get(directive));
     }

--- a/projects/spectator/src/lib/internals.ts
+++ b/projects/spectator/src/lib/internals.ts
@@ -68,8 +68,9 @@ export class Spectator<C> {
    * @returns
    */
   query<R extends Element>(directiveOrSelector: string | DOMSelector): R;
-  query<R>(directiveOrSelector: Type<any>, options?: { read }): R;
-  query<R>(directiveOrSelector: Type<any> | DOMSelector | string, options: { read } = { read: undefined }): R {
+  query<R>(directiveOrSelector: Type<R>): R;
+  query<R>(directiveOrSelector: Type<any>, options: { read: Type<R> }): R;
+  query<R>(directiveOrSelector: Type<any> | DOMSelector | string, options: { read: Type<R> } = { read: undefined }): R {
     try {
       return _getChild<R>(this.debugElement)(directiveOrSelector, options);
     } catch (err) {
@@ -88,8 +89,9 @@ export class Spectator<C> {
    * @returns
    */
   queryAll<R extends Element[]>(directiveOrSelector: string | DOMSelector): R;
-  queryAll<R>(directiveOrSelector: Type<any>, options?: { read }): R[];
-  queryAll<R>(directiveOrSelector: Type<any> | DOMSelector | string, options: { read } = { read: undefined }): R[] {
+  queryAll<R>(directiveOrSelector: Type<R>): R[];
+  queryAll<R>(directiveOrSelector: Type<any>, options: { read: Type<R> }): R[];
+  queryAll<R>(directiveOrSelector: Type<any> | DOMSelector | string, options: { read: Type<R> } = { read: undefined }): R[] {
     return _getChildren<R>(this.debugElement)(directiveOrSelector, options);
   }
 
@@ -100,8 +102,9 @@ export class Spectator<C> {
    * @returns
    */
   queryLast<R extends Element>(directiveOrSelector: string | DOMSelector): R;
-  queryLast<R>(directiveOrSelector: Type<any>, options?: { read }): R;
-  queryLast<R>(directiveOrSelector: Type<any> | DOMSelector | string, options: { read } = { read: undefined }): R {
+  queryLast<R>(directiveOrSelector: Type<R>): R;
+  queryLast<R>(directiveOrSelector: Type<any>, options: { read: Type<R> }): R;
+  queryLast<R>(directiveOrSelector: Type<R> | DOMSelector | string, options: { read: Type<R> } = { read: undefined }): R {
     const result = _getChildren<R>(this.debugElement)(directiveOrSelector, options);
     if (result && result.length) {
       return result[result.length - 1];
@@ -299,7 +302,7 @@ export class Spectator<C> {
  * @internal
  */
 export function _getChild<R>(debugElementRoot: DebugElement) {
-  return function(directiveOrSelector: Type<any> | DOMSelector | string, options: { read } = { read: undefined }): R {
+  return function(directiveOrSelector: Type<R> | DOMSelector | string, options: { read } = { read: undefined }): R {
     let debugElement: DebugElement;
 
     if (typeof directiveOrSelector === 'string') {
@@ -330,7 +333,7 @@ export function _getChild<R>(debugElementRoot: DebugElement) {
  * @internal
  */
 export function _getChildren<R>(debugElementRoot: DebugElement) {
-  return function(directiveOrSelector: Type<any> | DOMSelector | string, options: { read } = { read: undefined }): R[] {
+  return function(directiveOrSelector: Type<R> | DOMSelector | string, options: { read } = { read: undefined }): R[] {
     let debugElement: DebugElement[];
 
     if (typeof directiveOrSelector === 'string') {

--- a/projects/spectator/src/lib/service.ts
+++ b/projects/spectator/src/lib/service.ts
@@ -7,7 +7,7 @@
  */
 
 import { TestBed, TestModuleMetadata } from '@angular/core/testing';
-import { Provider, Type } from '@angular/core';
+import { InjectionToken, Type } from '@angular/core';
 import { mockProvider, SpyObject } from './mock';
 import { isType } from './is-type';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
@@ -15,7 +15,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 export interface SpectatorService<S> {
   service: S;
 
-  get<T>(token: any): T & SpyObject<T>;
+  get<T>(token: Type<T> | InjectionToken<T>): T & SpyObject<T>;
 }
 
 export type ServiceParams<S> = TestModuleMetadata & {
@@ -52,7 +52,7 @@ export function createService<S>(options: ServiceParams<S> | Type<S>): Spectator
     get service(): S {
       return TestBed.get(service);
     },
-    get<T>(token: any): T & SpyObject<T> {
+    get<T>(token: Type<T> | InjectionToken<T>): T & SpyObject<T> {
       return TestBed.get(token);
     }
   };

--- a/src/app/async/async.component.jest.ts
+++ b/src/app/async/async.component.jest.ts
@@ -23,7 +23,7 @@ describe('ZippyComponent', () => {
 
   it('should be truthy', () => {
     const host = createHost(`<app-async></app-async>`, false);
-    let queryService = host.get<QueryService>(QueryService);
+    let queryService = host.get(QueryService);
     queryService.select.mockReturnValue(of(true));
     host.detectChanges();
     expect(host.query('p')).toExist();

--- a/src/app/async/async.component.spec.ts
+++ b/src/app/async/async.component.spec.ts
@@ -23,7 +23,7 @@ describe('ZippyComponent', () => {
 
   it('should be truthy', () => {
     const host = createHost(`<app-async></app-async>`, false);
-    let queryService = host.get<QueryService>(QueryService);
+    let queryService = host.get(QueryService);
     queryService.select.and.returnValue(of(true));
     host.detectChanges();
     expect(host.query('p')).toExist();

--- a/src/app/auth.service.jest.ts
+++ b/src/app/auth.service.jest.ts
@@ -8,13 +8,13 @@ describe('AuthService', () => {
     mocks: [DateService]
   });
   it('should not be logged in', () => {
-    const dateService = spectator.get<DateService>(DateService);
+    const dateService = spectator.get(DateService);
     dateService.isExpired.mockReturnValue(true);
     expect(spectator.service.isLoggedIn()).toBeFalsy();
   });
 
   it('should be logged in', () => {
-    const dateService = spectator.get<DateService>(DateService);
+    const dateService = spectator.get(DateService);
     dateService.isExpired.mockReturnValue(false);
     expect(spectator.service.isLoggedIn()).toBeTruthy();
   });

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -11,13 +11,13 @@ describe('AuthService', () => {
   });
 
   it('should not be logged in', () => {
-    const dateService = spectator.get<DateService>(DateService);
+    const dateService = spectator.get(DateService);
     dateService.isExpired.and.returnValue(true);
     expect(spectator.service.isLoggedIn()).toBeFalsy();
   });
 
   it('should be logged in', () => {
-    const dateService = spectator.get<DateService>(DateService);
+    const dateService = spectator.get(DateService);
     dateService.isExpired.and.returnValue(false);
     expect(spectator.service.isLoggedIn()).toBeTruthy();
   });

--- a/src/app/auto-focus.directive.jest.ts
+++ b/src/app/auto-focus.directive.jest.ts
@@ -17,7 +17,7 @@ describe('DatoAutoFocusDirective', function() {
 
   it('should be focused', () => {
     host = createHost(`<input datoAutoFocus="true">`);
-    const instance = host.getDirectiveInstance<AutoFocusDirective>(AutoFocusDirective);
+    const instance = host.getDirectiveInstance(AutoFocusDirective);
     expect(host.element).toBeFocused();
   });
 

--- a/src/app/auto-focus.directive.spec.ts
+++ b/src/app/auto-focus.directive.spec.ts
@@ -17,7 +17,7 @@ describe('DatoAutoFocusDirective', function() {
 
   it('should be focused', () => {
     host = createHost(`<input datoAutoFocus="true">`);
-    const instance = host.getDirectiveInstance<AutoFocusDirective>(AutoFocusDirective);
+    const instance = host.getDirectiveInstance(AutoFocusDirective);
     expect(host.element).toBeFocused();
   });
 

--- a/src/app/button/button.component.jest.ts
+++ b/src/app/button/button.component.jest.ts
@@ -40,7 +40,7 @@ describe('ButtonComponent', () => {
 
   it('should mock the service', () => {
     spectator = createComponent({}, false);
-    spectator.get<QueryService>(QueryService, true).selectName.and.returnValue(of('Netanel'));
+    spectator.get(QueryService, true).selectName.and.returnValue(of('Netanel'));
     spectator.detectChanges();
     expect(spectator.query('p')).toHaveText('Netanel');
   });

--- a/src/app/button/button.component.spec.ts
+++ b/src/app/button/button.component.spec.ts
@@ -40,7 +40,7 @@ describe('ButtonComponent', () => {
 
   it('should mock the service', () => {
     spectator = createComponent({}, false);
-    spectator.get<QueryService>(QueryService, true).selectName.and.returnValue(of('Netanel'));
+    spectator.get(QueryService, true).selectName.and.returnValue(of('Netanel'));
     spectator.detectChanges();
     expect(spectator.query('p')).toHaveText('Netanel');
   });

--- a/src/app/consumer.service.jest.ts
+++ b/src/app/consumer.service.jest.ts
@@ -16,7 +16,7 @@ describe('ConsumerService', () => {
   });
 
   it('should consume mocked service with properties', () => {
-    const provider = spectator.get<ProviderService>(ProviderService);
+    const provider = spectator.get(ProviderService);
     expect(spectator.service.lastValue).toBeUndefined();
     provider.obs$.next('hey you');
     expect(spectator.service.lastValue).toBe('hey you');

--- a/src/app/consumer.service.spec.ts
+++ b/src/app/consumer.service.spec.ts
@@ -16,7 +16,7 @@ describe('ConsumerService', () => {
   });
 
   it('should consume mocked service with properties', () => {
-    const provider = spectator.get<ProviderService>(ProviderService);
+    const provider = spectator.get(ProviderService);
     expect(spectator.service.lastValue).toBeUndefined();
     provider.obs$.next('hey you');
     expect(spectator.service.lastValue).toBe('hey you');

--- a/src/app/form-input/form-input.component.jest.ts
+++ b/src/app/form-input/form-input.component.jest.ts
@@ -32,7 +32,7 @@ describe('FormInputComponent', () => {
     enableSubnet: true
   };
 
-  const createComponent = createTestComponentFactory<FormInputComponent>({
+  const createComponent = createTestComponentFactory({
     component: FormInputComponent,
     imports: [ReactiveFormsModule]
   });

--- a/src/app/todos-data.service.jest.ts
+++ b/src/app/todos-data.service.jest.ts
@@ -5,7 +5,7 @@ import { TodosDataService, UserService } from './todos-data.service';
 import { createHTTPFactory, mockProvider } from '@netbasal/spectator/jest';
 
 describe('HttpClient testing', () => {
-  const http = createHTTPFactory<TodosDataService>(TodosDataService, [mockProvider(UserService)]);
+  const http = createHTTPFactory(TodosDataService, [mockProvider(UserService)]);
 
   it('can test HttpClient.get', () => {
     const { dataService, expectOne } = http();

--- a/src/app/todos-data.service.spec.ts
+++ b/src/app/todos-data.service.spec.ts
@@ -4,7 +4,7 @@ import { createHTTPFactory, HTTPMethod, mockProvider } from '@netbasal/spectator
 import { TodosDataService, UserService } from './todos-data.service';
 
 describe('HttpClient testing', () => {
-  const http = createHTTPFactory<TodosDataService>(TodosDataService, [mockProvider(UserService)]);
+  const http = createHTTPFactory(TodosDataService, [mockProvider(UserService)]);
 
   it('can test HttpClient.get', () => {
     const { dataService, expectOne } = http();

--- a/src/app/view-children/view-children.component.jest.ts
+++ b/src/app/view-children/view-children.component.jest.ts
@@ -18,10 +18,10 @@ describe('ViewChildrenComponent', () => {
   });
 
   it('should expose the view child', () => {
-    const serviceFromChild = spectator.query<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const serviceFromChild = spectator.query(ChildComponent, { read: ChildServiceService });
     const div = spectator.query('div');
-    const component = spectator.query<ChildComponent>(ChildComponent);
-    const { nativeElement } = spectator.query<ElementRef>(ChildComponent, {
+    const component = spectator.query(ChildComponent);
+    const { nativeElement } = spectator.query(ChildComponent, {
       read: ElementRef
     });
     const button = spectator.query('button');
@@ -32,9 +32,9 @@ describe('ViewChildrenComponent', () => {
   });
 
   it('should expose the view children', () => {
-    const serviceFromChild = spectator.queryAll<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const serviceFromChild = spectator.queryAll(ChildComponent, { read: ChildServiceService });
     const divs = spectator.queryAll('div');
-    const components = spectator.queryAll<ChildComponent>(ChildComponent);
+    const components = spectator.queryAll(ChildComponent);
     expect(serviceFromChild.length).toBe(4);
     expect(components.length).toBe(4);
     expect(divs.length).toBe(2);
@@ -58,7 +58,7 @@ describe('ContentChild', () => {
       </app-view-children>
     `);
 
-    const contentChilds = host.queryAll<ChildComponent>(ChildComponent);
+    const contentChilds = host.queryAll(ChildComponent);
     expect(contentChilds.length).toBe(6);
   });
 });

--- a/src/app/view-children/view-children.component.spec.ts
+++ b/src/app/view-children/view-children.component.spec.ts
@@ -18,10 +18,10 @@ describe('ViewChildrenComponent', () => {
   });
 
   it('should expose the view child', () => {
-    const serviceFromChild = spectator.query<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const serviceFromChild = spectator.query(ChildComponent, { read: ChildServiceService });
     const div = spectator.query('div');
-    const component = spectator.query<ChildComponent>(ChildComponent);
-    const { nativeElement } = spectator.query<ElementRef>(ChildComponent, {
+    const component = spectator.query(ChildComponent);
+    const { nativeElement } = spectator.query(ChildComponent, {
       read: ElementRef
     });
     const button = spectator.query('button');
@@ -32,9 +32,9 @@ describe('ViewChildrenComponent', () => {
   });
 
   it('should expose the view children', () => {
-    const serviceFromChild = spectator.queryAll<ChildServiceService>(ChildComponent, { read: ChildServiceService });
+    const serviceFromChild = spectator.queryAll(ChildComponent, { read: ChildServiceService });
     const divs = spectator.queryAll('div');
-    const components = spectator.queryAll<ChildComponent>(ChildComponent);
+    const components = spectator.queryAll(ChildComponent);
     expect(serviceFromChild.length).toBe(4);
     expect(components.length).toBe(4);
     expect(divs.length).toBe(2);
@@ -58,7 +58,7 @@ describe('ContentChild', () => {
       </app-view-children>
     `);
 
-    const contentChilds = host.queryAll<ChildComponent>(ChildComponent);
+    const contentChilds = host.queryAll(ChildComponent);
     expect(contentChilds.length).toBe(6);
   });
 });

--- a/src/app/widget/widget.component.jest.ts
+++ b/src/app/widget/widget.component.jest.ts
@@ -5,7 +5,7 @@ import { WidgetComponent } from './widget.component';
 describe('WidgetComponent', () => {
   let host: SpectatorWithHost<WidgetComponent>;
 
-  const createHost = createHostComponentFactory<WidgetComponent>({
+  const createHost = createHostComponentFactory({
     component: WidgetComponent,
     mocks: [WidgetService]
   });

--- a/src/app/zippy/zippy.component.jest.ts
+++ b/src/app/zippy/zippy.component.jest.ts
@@ -8,7 +8,7 @@ import { ZippyComponent } from './zippy.component';
 describe('ZippyComponent', () => {
   let host: SpectatorWithHost<ZippyComponent>;
 
-  const createHost = createHostComponentFactory<ZippyComponent>({
+  const createHost = createHostComponentFactory({
     component: ZippyComponent,
     mocks: [QueryService],
     componentProviders: [{ provide: QueryService, useValue: 'componentProviders' }]

--- a/src/app/zippy/zippy.component.spec.ts
+++ b/src/app/zippy/zippy.component.spec.ts
@@ -9,7 +9,7 @@ import { CalcComponent } from '../calc/calc.component';
 describe('ZippyComponent', () => {
   let host: SpectatorWithHost<ZippyComponent>;
 
-  const createHost = createHostComponentFactory<ZippyComponent>({
+  const createHost = createHostComponentFactory({
     component: ZippyComponent,
     mocks: [QueryService],
     declarations: [CalcComponent],
@@ -130,7 +130,7 @@ class CustomHostComponent {
 describe('With Custom Host Component', function() {
   let host: SpectatorWithHost<ZippyComponent, CustomHostComponent>;
 
-  const createHost = createHostComponentFactory<ZippyComponent, CustomHostComponent>({
+  const createHost = createHostComponentFactory({
     component: ZippyComponent,
     componentProviders: [{ provide: QueryService, useValue: 'componentProviders' }],
     host: CustomHostComponent


### PR DESCRIPTION
This PR improves type inference for the following methods:

* `SpectatorService.get`
* `SpectatorWithHost.getDirectiveInstance`
* `Spectator.query`
* `Spectator.queryAll`
* `Spectator.queryLast`

Before:
```typescript
const fooService = spectatorService.get<FooService>(FooService);
const fooDirective = host.getDirectiveInstance<FooDirective>(FooDirective);
const barDirective = spectator.query<BarDirective>(BarDirective);
const bazDirectives = spectator.queryAll<BazDirective>(BazDirective);
const someElementRef = spectator.query<ElementRef>(BarDirective, { read: ElementRef });
```
Now, you can omit the generic type and profit from type inference:
```typescript
const fooService = spectatorService.get(FooService);
const fooDirective = host.getDirectiveInstance(FooDirective);
const barDirective = spectator.query(BarDirective);
const bazDirectives = spectator.queryAll(BazDirective);
const someElementRef = spectator.query(BarDirective, { read: ElementRef });
```

The demo app has been updated accordingly. This change is backwards compatible.

The docs may need to be updated.