### PR TITLE
fix(mock): fix regression caused by mocked properties

### DIFF
--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -32,8 +32,10 @@ export function installProtoMethods(mock: any, proto: any, createSpyFn: Function
 
     if (typeof descriptor.value === 'function' && key !== 'constructor' && typeof mock[key] === 'undefined') {
       mock[key] = createSpyFn(key);
-    } else if (descriptor.get || descriptor.set) {
-      Object.defineProperty(mock, key, descriptor);
+    } else if (descriptor.get && !mock.hasOwnProperty(key)) {
+      Object.defineProperty(mock, key, {
+        get: () => null
+      });
     }
   }
 

--- a/src/app/spy-object/spy-object.jest.ts
+++ b/src/app/spy-object/spy-object.jest.ts
@@ -12,12 +12,9 @@ describe('SpyObject', () => {
   it('should keep getters/setters', () => {
     const person = createSpyObject(Person);
     person.birthYear = 1990;
+    jest.spyOn(person, 'age', 'get').mockReturnValue(29);
 
     expect(person.age).toBe(29);
-
-    jest.spyOn(person, 'age', 'get').mockReturnValue(100);
-
-    expect(person.age).toBe(100);
   });
 
   it('should allow setting properties', () => {

--- a/src/app/spy-object/spy-object.spec.ts
+++ b/src/app/spy-object/spy-object.spec.ts
@@ -9,9 +9,10 @@ describe('SpyObject', () => {
     person.sayHi.andReturn('Bye!');
   });
 
-  it('should keep getters/setters', () => {
+  it('should enable spying on properties', () => {
     const person = createSpyObject(Person);
     person.birthYear = 1990;
+    spyOnProperty(person, 'age', 'get').and.returnValue(29);
 
     expect(person.age).toBe(29);
   });


### PR DESCRIPTION
So I did a small test to check breaking changes in v4. Turns out the only issue for on of our projects was a regression introduced in 3.11.1 :smile: in this change: https://github.com/NetanelBasal/spectator/commit/977059a0e7e89017f6ddd775b0fbacf46fdedc66. 

This PR improves that change by:
* using a null return instead of the real descriptor. The real descriptor may need to access stuff that does not exists on the mock object, so it makes no sense to use that one.
* it skips properties that may already exist due to custom decorators
* it skips setters (no reason to mock them explicitly)

This fix still enables you to spy on a property, which was the reason to add it in the first place.