### PR TITLE
feat: add factory for SpectatorForDirective

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ describe('With Custom Host Component', function () {
 });
 ```
 ## Testing Directives
+
+There is a special test factory for testing directives.  
+
 Let's say we have the following directive:
 
 ```ts
@@ -300,28 +303,28 @@ export class HighlightDirective {
 Let's see how we can test directives easily with Spectator:
 ```ts
 describe('HighlightDirective', () => {
-  let host: SpectatorWithHost<HighlightDirective>;
-  const createHost = createHostComponentFactory(HighlightDirective);
+  let spectator: SpectatorForDirective<HighlightDirective>;
+  const createHost = createHostDirectiveFactory(HighlightDirective);
 
   beforeEach(() => {
-    host = createHost(`<div highlight>Testing Highlight Directive</div>`);
+    spectator = createHost(`<div highlight>Testing Highlight Directive</div>`);
   });
 
   it('should change the background color', () => {
-    host.dispatchMouseEvent(host.element, 'mouseover');
+    spectator.dispatchMouseEvent(spectator.element, 'mouseover');
 
-    expect(host.element).toHaveStyle({
+    expect(spectator.element).toHaveStyle({
       backgroundColor: 'rgba(0,0,0, 0.1)'
     });
 
-    host.dispatchMouseEvent(host.element, 'mouseout');
-    expect(host.element).toHaveStyle({
+    spectator.dispatchMouseEvent(spectator.element, 'mouseout');
+    expect(spectator.element).toHaveStyle({
       backgroundColor: '#fff'
     });
   });
 
   it('should get the instance', () => {
-    const instance = host.query(HighlightDirective);
+    const instance = spectator.directive;
     expect(instance).toBeDefined();
   });
 });

--- a/projects/spectator/jest/src/lib/spectator-for-directive.ts
+++ b/projects/spectator/jest/src/lib/spectator-for-directive.ts
@@ -1,0 +1,41 @@
+import { Type } from '@angular/core';
+import {
+  createHostDirectiveFactory as baseCreateHostDirectiveFactory,
+  isType,
+  HostComponent,
+  SpectatorForDirective as BaseSpectatorForDirective,
+  SpectatorForDirectiveOptions,
+  SpectatorForDirectiveOverrides,
+  Token
+} from '@netbasal/spectator';
+
+import { mockProvider, SpyObject } from './mock';
+
+/**
+ * @publicApi
+ */
+export class SpectatorForDirective<C, H = HostComponent> extends BaseSpectatorForDirective<C, H> {
+  public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
+    return super.get(type, fromComponentInjector) as SpyObject<T>;
+  }
+}
+
+/**
+ * @publicApi
+ */
+export type SpectatorForDirectiveFactory<C, H> = (
+  template: string,
+  overrides?: SpectatorForDirectiveOverrides<C, H>
+) => SpectatorForDirective<C, H>;
+
+/**
+ * @publicApi
+ */
+export function createHostDirectiveFactory<C, H = HostComponent>(
+  typeOrOptions: SpectatorForDirectiveOptions<C, H> | Type<C>
+): SpectatorForDirectiveFactory<C, H> {
+  return baseCreateHostDirectiveFactory({
+    mockProvider,
+    ...(isType(typeOrOptions) ? { directive: typeOrOptions } : typeOrOptions)
+  });
+}

--- a/projects/spectator/jest/src/public_api.ts
+++ b/projects/spectator/jest/src/public_api.ts
@@ -5,6 +5,7 @@ export * from './lib/http';
 export * from './lib/mock';
 export * from './lib/spectator';
 export * from './lib/spectator-http';
+export * from './lib/spectator-for-directive';
 export * from './lib/spectator-service';
 export * from './lib/spectator-with-host';
 export * from './lib/spectator-with-routing';

--- a/projects/spectator/jest/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/jest/test/auto-focus.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { SpectatorWithHost, createHostComponentFactory } from '@netbasal/spectator/jest';
+import { SpectatorWithHost, createHostComponentFactory, createHostDirectiveFactory, SpectatorForDirective } from '@netbasal/spectator/jest';
 
 import { AutoFocusDirective } from '../../test/auto-focus.directive';
 
@@ -19,6 +19,41 @@ describe('DatoAutoFocusDirective', () => {
   it('should be focused', () => {
     host = createHost(`<input datoAutoFocus="true">`);
     const instance = host.queryHost(AutoFocusDirective);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should NOT be focused', () => {
+    host = createHost(`<input [datoAutoFocus]="false">`);
+    expect(host.element).not.toBeFocused();
+  });
+
+  it('should work with dynamic input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`);
+    expect(host.element).not.toBeFocused();
+    host.setHostInput({ isFocused: true });
+    expect(host.element).toBeFocused();
+  });
+
+  it('should be able to type in input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`);
+
+    host.typeInElement('foo');
+    expect(host.element).toHaveValue('foo');
+  });
+});
+describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
+  let host: SpectatorForDirective<AutoFocusDirective, CustomHostComponent>;
+
+  const createHost = createHostDirectiveFactory({
+    directive: AutoFocusDirective,
+    host: CustomHostComponent
+  });
+
+  it('should be focused', () => {
+    host = createHost(`<input datoAutoFocus="true">`);
+    const instance1 = host.query(AutoFocusDirective);
+    const instance2 = host.directive;
+    expect(instance1).toBe(instance2);
     expect(host.element).toBeFocused();
   });
 

--- a/projects/spectator/jest/test/highlight.directive.spec.ts
+++ b/projects/spectator/jest/test/highlight.directive.spec.ts
@@ -1,4 +1,4 @@
-import { SpectatorWithHost } from '@netbasal/spectator';
+import { createHostDirectiveFactory, SpectatorForDirective, SpectatorWithHost } from '@netbasal/spectator';
 import { createHostComponentFactory } from '@netbasal/spectator/jest';
 
 import { HighlightDirective } from '../../test/highlight.directive';
@@ -7,6 +7,28 @@ describe('HighlightDirective', () => {
   let host: SpectatorWithHost<HighlightDirective>;
 
   const createHost = createHostComponentFactory(HighlightDirective);
+
+  // calculated styles not supported in JSDOM
+  xit('should change the background color', () => {
+    host = createHost(`<div highlight>Testing HighlightDirective</div>`);
+
+    host.dispatchMouseEvent(host.element, 'mouseover');
+
+    expect(host.element).toHaveStyle({
+      backgroundColor: 'rgba(0,0,0, 0.1)'
+    });
+
+    host.dispatchMouseEvent(host.element, 'mouseout');
+    expect(host.element).toHaveStyle({
+      backgroundColor: '#fff'
+    });
+  });
+});
+
+describe('HighlightDirective (createHostDirectiveFactory)', () => {
+  let host: SpectatorForDirective<HighlightDirective>;
+
+  const createHost = createHostDirectiveFactory(HighlightDirective);
 
   // calculated styles not supported in JSDOM
   xit('should change the background color', () => {

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -1,0 +1,228 @@
+import { ChangeDetectorRef, DebugElement, ElementRef, Type } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { Token } from '../token';
+import { DOMSelector } from '../dom-selectors';
+import { isString, QueryOptions, QueryType, SpectatorElement } from '../types';
+import { SpyObject } from '../mock';
+import { getChildren, setProps } from '../internals/query';
+import { patchElementFocus } from '../internals/element-focus';
+import { createMouseEvent } from '../internals/event-objects';
+import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent, dispatchTouchEvent } from '../internals/dispatch-events';
+import { typeInElement } from '../internals/type-in-element';
+
+import { BaseSpectator } from './base-spectator';
+
+const KEY_UP = 'keyup';
+
+/**
+ * @internal
+ */
+export abstract class DomSpectator<I> extends BaseSpectator {
+  constructor(public fixture: ComponentFixture<any>, public debugElement: DebugElement, protected instance: I, public element: Element) {
+    super();
+  }
+
+  public get<T>(type: Token<T> | Token<any>): SpyObject<T> {
+    return super.get(type);
+  }
+
+  public detectChanges(): void {
+    this.fixture.detectChanges();
+  }
+
+  public query<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
+  public query<R>(directive: Type<R>): R | null;
+  public query<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
+  public query<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
+    if ((options || {}).root && isString(directiveOrSelector)) {
+      return document.querySelector(directiveOrSelector);
+    }
+
+    return getChildren<R>(this.debugElement)(directiveOrSelector, options)[0] || null;
+  }
+
+  public queryAll<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R[];
+  public queryAll<R>(directive: Type<R>): R[];
+  public queryAll<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R[];
+  public queryAll<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R[] | Element[] {
+    if ((options || {}).root && isString(directiveOrSelector)) {
+      return Array.from(document.querySelectorAll(directiveOrSelector));
+    }
+
+    return getChildren<R>(this.debugElement)(directiveOrSelector, options);
+  }
+
+  public queryLast<R extends Element[]>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
+  public queryLast<R>(directive: Type<R>): R | null;
+  public queryLast<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
+  public queryLast<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
+    if ((options || {}).root && isString(directiveOrSelector)) {
+      return document.querySelector(directiveOrSelector);
+    }
+    const result = getChildren<R>(this.debugElement)(directiveOrSelector, options);
+    if (result && result.length) {
+      return result[result.length - 1];
+    }
+
+    return null;
+  }
+
+  public setInput<K extends keyof I>(input: Partial<I>): void;
+  public setInput<K extends keyof I>(input: K, inputValue: I[K]): void;
+  public setInput<K extends keyof I>(input: Partial<I> | K, value?: I[K]): void {
+    setProps(this.instance, input, value);
+    this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
+  }
+
+  public output<T, K extends keyof I = keyof I>(output: K): Observable<T> {
+    const observable = this.instance[output];
+
+    if (!(observable instanceof Observable)) {
+      throw new Error(`${output} is not an @Output`);
+    }
+
+    return observable as Observable<T>;
+  }
+
+  public click(selector: SpectatorElement = this.element): void {
+    const element = this.getNativeElement(selector);
+
+    if (!(element instanceof HTMLElement)) {
+      throw new Error(`Cannot click: ${selector} is not a HTMLElement`);
+    }
+
+    element.click();
+    this.detectChanges();
+  }
+
+  public blur(selector: SpectatorElement = this.element): void {
+    const element = this.getNativeElement(selector);
+
+    if (!(element instanceof HTMLElement)) {
+      throw new Error(`Cannot blur: ${selector} is not a HTMLElement`);
+    }
+
+    patchElementFocus(element);
+    element.blur();
+    this.detectChanges();
+  }
+
+  public focus(selector: SpectatorElement = this.element): void {
+    const element = this.getNativeElement(selector);
+
+    if (!(element instanceof HTMLElement)) {
+      throw new Error(`Cannot focus: ${selector} is not a HTMLElement`);
+    }
+
+    patchElementFocus(element);
+    element.focus();
+    this.detectChanges();
+  }
+
+  public dispatchMouseEvent(
+    selector: SpectatorElement = this.element,
+    type: string,
+    x: number = 0,
+    y: number = 0,
+    event: MouseEvent = createMouseEvent(type, x, y)
+  ): MouseEvent {
+    const element = this.getNativeElement(selector);
+
+    if (!(element instanceof Node)) {
+      throw new Error(`Cannot dispatch mouse event: ${selector} is not a node`);
+    }
+
+    const dispatchedEvent = dispatchMouseEvent(element, type, x, y, event);
+    this.detectChanges();
+
+    return dispatchedEvent;
+  }
+
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyCode: number, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, key: string, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(
+    selector: SpectatorElement = this.element,
+    type: string,
+    keyOrKeyCode: string | number,
+    target?: Element
+  ): KeyboardEvent {
+    const element = this.getNativeElement(selector);
+
+    if (!(element instanceof Node)) {
+      throw new Error(`Cannot dispatch keyboard event: ${selector} is not a node`);
+    }
+
+    const event = dispatchKeyboardEvent(element, type, keyOrKeyCode, target);
+
+    this.detectChanges();
+
+    return event;
+  }
+
+  public dispatchFakeEvent(selector: SpectatorElement = this.element, type: string, canBubble?: boolean): Event {
+    const event = dispatchFakeEvent(this.getNativeElement(selector), type, canBubble);
+    this.detectChanges();
+
+    return event;
+  }
+
+  public get keyboard(): any {
+    return {
+      pressKey: (key: string, selector: SpectatorElement = this.element, event = KEY_UP) => {
+        this.dispatchKeyboardEvent(selector, event, key);
+      },
+      pressEscape: (selector: SpectatorElement = this.element, event = KEY_UP) => {
+        this.dispatchKeyboardEvent(selector, event, 'Escape');
+      },
+      pressEnter: (selector: SpectatorElement = this.element, event = KEY_UP) => {
+        this.dispatchKeyboardEvent(selector, event, 'Enter');
+      },
+      pressTab: (selector: SpectatorElement = this.element, event = KEY_UP) => {
+        this.dispatchKeyboardEvent(selector, event, 'Tab');
+      },
+      pressBackspace: (selector: SpectatorElement = this.element, event = KEY_UP) => {
+        this.dispatchKeyboardEvent(selector, event, 'Backspace');
+      }
+    };
+  }
+
+  public dispatchTouchEvent(selector: SpectatorElement = this.element, type: string, x: number = 0, y: number = 0): void {
+    dispatchTouchEvent(this.getNativeElement(selector), type, x, y);
+    this.detectChanges();
+  }
+
+  public typeInElement(value: string, selector: SpectatorElement = this.element): void {
+    typeInElement(value, this.getNativeElement(selector));
+    this.detectChanges();
+  }
+
+  private getNativeElement(selector: SpectatorElement): HTMLElement | Window | Document {
+    let element;
+
+    // Support global objects window and document
+    if (selector === window || selector === document) {
+      return selector;
+    }
+
+    if (isString(selector)) {
+      const exists = this.debugElement.query(By.css(selector));
+      if (exists) {
+        element = exists.nativeElement;
+      } else {
+        // tslint:disable:no-console
+        console.error(`${selector} does not exists`);
+      }
+    } else {
+      if (selector instanceof DebugElement || selector instanceof ElementRef) {
+        element = selector.nativeElement;
+      } else {
+        element = selector;
+      }
+    }
+
+    return element;
+  }
+}

--- a/projects/spectator/src/lib/internals/query.ts
+++ b/projects/spectator/src/lib/internals/query.ts
@@ -26,15 +26,15 @@ export function getChildren<R>(debugElementRoot: DebugElement): (directiveOrSele
   };
 }
 
-export function setComponentProps(component: any, key: any, value: any): void;
-export function setComponentProps(component: any, keyValues: any): void;
-export function setComponentProps(component: any, keyOrKeyValues: any, value?: any): void {
+export function setProps(instance: any, key: any, value: any): void;
+export function setProps(instance: any, keyValues: any): void;
+export function setProps(instance: any, keyOrKeyValues: any, value?: any): void {
   if (isString(keyOrKeyValues)) {
-    component[keyOrKeyValues] = value;
+    instance[keyOrKeyValues] = value;
   } else {
     // tslint:disable-next-line:forin
     for (const p in keyOrKeyValues) {
-      component[p] = keyOrKeyValues[p];
+      instance[p] = keyOrKeyValues[p];
     }
   }
 }

--- a/projects/spectator/src/lib/spectator-for-directive/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-for-directive/create-factory.ts
@@ -1,0 +1,96 @@
+import { Provider, Type } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+
+import { setProps } from '../internals/query';
+import * as customMatchers from '../matchers';
+import { isType } from '../types';
+import { HostComponent } from '../spectator-with-host/host-component';
+import { BaseSpectatorOverrides } from '../base/options';
+
+import { initialSpectatorForDirectiveModule } from './initial-module';
+import { getSpectatorForDirectiveDefaultOptions, SpectatorForDirectiveOptions } from './options';
+import { SpectatorForDirective } from './spectator-for-directive';
+
+/**
+ * @publicApi
+ */
+export type SpectatorForDirectiveFactory<D, H> = (
+  template: string,
+  overrides?: SpectatorForDirectiveOverrides<D, H>
+) => SpectatorForDirective<D, H>;
+
+/**
+ * @publicApi
+ */
+export interface SpectatorForDirectiveOverrides<D, H> extends BaseSpectatorOverrides {
+  detectChanges?: boolean;
+  props?: Partial<D>;
+  hostProps?: H extends HostComponent
+    ? {
+        [key: string]: any;
+      }
+    : Partial<H>;
+}
+
+/**
+ * @publicApi
+ */
+export function createHostDirectiveFactory<D, H = HostComponent>(
+  typeOrOptions: Type<D> | SpectatorForDirectiveOptions<D, H>
+): SpectatorForDirectiveFactory<D, H> {
+  const options = isType(typeOrOptions)
+    ? getSpectatorForDirectiveDefaultOptions<D, H>({ directive: typeOrOptions })
+    : getSpectatorForDirectiveDefaultOptions(typeOrOptions);
+
+  const moduleMetadata = initialSpectatorForDirectiveModule<D, H>(options);
+
+  beforeEach(async(() => {
+    jasmine.addMatchers(customMatchers as any);
+    TestBed.configureTestingModule(moduleMetadata);
+  }));
+
+  return (template: string, overrides?: SpectatorForDirectiveOverrides<D, H>) => {
+    const defaults: SpectatorForDirectiveOverrides<D, H> = { props: {}, hostProps: {} as any, detectChanges: true, providers: [] };
+    const { detectChanges, props, hostProps, providers } = { ...defaults, ...overrides };
+
+    if (providers && providers.length) {
+      providers.forEach((provider: Provider) => {
+        TestBed.overrideProvider((provider as any).provide, provider as any);
+      });
+    }
+
+    TestBed.overrideModule(BrowserDynamicTestingModule, {
+      set: {
+        entryComponents: moduleMetadata.entryComponents
+      }
+    }).overrideComponent(options.host, {
+      set: { template }
+    });
+
+    const spectator = createSpectatorForDirective<D, H>(options);
+
+    setProps(spectator.directive, props);
+    setProps(spectator.hostComponent, hostProps);
+
+    if (options.detectChanges && detectChanges) {
+      spectator.detectChanges();
+    }
+
+    return spectator;
+  };
+}
+
+function createSpectatorForDirective<D, H>(options: Required<SpectatorForDirectiveOptions<D, H>>): SpectatorForDirective<D, H> {
+  const hostFixture = TestBed.createComponent(options.host);
+  const debugElement = hostFixture.debugElement.query(By.directive(options.directive));
+
+  return new SpectatorForDirective<D, H>(
+    hostFixture.componentInstance,
+    hostFixture,
+    hostFixture.debugElement,
+    debugElement.componentInstance,
+    debugElement.nativeElement
+  );
+}

--- a/projects/spectator/src/lib/spectator-for-directive/initial-module.ts
+++ b/projects/spectator/src/lib/spectator-for-directive/initial-module.ts
@@ -1,0 +1,22 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { initialModule, ModuleMetadata } from '../base/initial-module';
+import { HostComponent } from '../spectator-with-host/host-component';
+
+import { SpectatorForDirectiveOptions } from './options';
+
+/**
+ * @internal
+ */
+export function initialSpectatorForDirectiveModule<D, H = HostComponent>(
+  options: Required<SpectatorForDirectiveOptions<D>>
+): ModuleMetadata {
+  const moduleMetadata = initialModule(options);
+
+  moduleMetadata.declarations.push(options.directive);
+  moduleMetadata.declarations.push(options.host);
+
+  moduleMetadata.schemas = [options.shallow ? NO_ERRORS_SCHEMA : options.schemas || []];
+
+  return moduleMetadata;
+}

--- a/projects/spectator/src/lib/spectator-for-directive/options.ts
+++ b/projects/spectator/src/lib/spectator-for-directive/options.ts
@@ -1,0 +1,34 @@
+import { Type } from '@angular/core';
+
+import { merge } from '../internals/merge';
+import { OptionalsRequired } from '../types';
+import { BaseSpectatorOptions, getDefaultBaseOptions } from '../base/options';
+import { HostComponent } from '../spectator-with-host/host-component';
+
+/**
+ * @publicApi
+ */
+export interface SpectatorForDirectiveOptions<D = any, H = HostComponent> extends BaseSpectatorOptions {
+  directive: Type<D>;
+  shallow?: boolean;
+  detectChanges?: boolean;
+  host?: Type<H>;
+  template?: string;
+}
+
+const defaultSpectatorWithHostOptions: OptionalsRequired<SpectatorForDirectiveOptions> = {
+  ...getDefaultBaseOptions(),
+  host: HostComponent,
+  template: '',
+  shallow: false,
+  detectChanges: true
+};
+
+/**
+ * @internal
+ */
+export function getSpectatorForDirectiveDefaultOptions<D, H>(
+  overrides: SpectatorForDirectiveOptions<D, H>
+): Required<SpectatorForDirectiveOptions<D, H>> {
+  return merge(defaultSpectatorWithHostOptions, overrides) as Required<SpectatorForDirectiveOptions<D, H>>;
+}

--- a/projects/spectator/src/lib/spectator-for-directive/spectator-for-directive.ts
+++ b/projects/spectator/src/lib/spectator-for-directive/spectator-for-directive.ts
@@ -1,0 +1,42 @@
+import { DebugElement } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+
+import { setProps } from '../internals/query';
+import { Token } from '../token';
+import { DomSpectator } from '../base/dom-spectator';
+import { SpyObject } from '../mock';
+import { HostComponent } from '../spectator-with-host/host-component';
+
+/**
+ * @publicApi
+ */
+export class SpectatorForDirective<D, H = HostComponent> extends DomSpectator<D> {
+  constructor(
+    public hostComponent: H,
+    public fixture: ComponentFixture<H>,
+    public debugElement: DebugElement,
+    protected instance: D,
+    public element: Element
+  ) {
+    super(fixture, debugElement, instance, element);
+  }
+
+  public get directive(): D {
+    return this.instance;
+  }
+
+  public get<T>(type: Token<T> | Token<any>, fromDirectiveInjector: boolean = false): SpyObject<T> {
+    if (fromDirectiveInjector) {
+      return this.debugElement.injector.get(type) as SpyObject<T>;
+    }
+
+    return super.get(type);
+  }
+
+  public setHostInput<K extends keyof H>(input: Partial<H>): void;
+  public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
+  public setHostInput<K extends keyof H>(input: Partial<H> | K, value?: H[K]): void {
+    setProps(this.hostComponent, input, value);
+    this.detectChanges();
+  }
+}

--- a/projects/spectator/src/lib/spectator-with-host/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-with-host/create-factory.ts
@@ -3,7 +3,7 @@ import { async, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
-import { setComponentProps } from '../internals/query';
+import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { SpectatorOverrides } from '../spectator/create-factory';
 import { isType } from '../types';
@@ -74,8 +74,8 @@ export function createHostComponentFactory<C, H = HostComponent>(
 
     const spectator = createSpectatorWithHost<C, H>(options);
 
-    setComponentProps(spectator.component, props);
-    setComponentProps(spectator.hostComponent, hostProps);
+    setProps(spectator.component, props);
+    setProps(spectator.hostComponent, hostProps);
 
     if (options.detectChanges && detectChanges) {
       spectator.detectChanges();

--- a/projects/spectator/src/lib/spectator-with-host/spectator-with-host.ts
+++ b/projects/spectator/src/lib/spectator-with-host/spectator-with-host.ts
@@ -2,7 +2,7 @@ import { DebugElement, Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 
 import { DOMSelector } from '../dom-selectors';
-import { getChildren, setComponentProps } from '../internals/query';
+import { getChildren, setProps } from '../internals/query';
 import { Spectator } from '../spectator/spectator';
 import { Token } from '../token';
 import { isString, QueryOptions, QueryType } from '../types';
@@ -53,7 +53,7 @@ export class SpectatorWithHost<C, H = HostComponent> extends Spectator<C> {
   public setHostInput<K extends keyof H>(input: Partial<H>): void;
   public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
   public setHostInput<K extends keyof H>(input: Partial<H> | K, value?: H[K]): void {
-    setComponentProps(this.hostComponent, input, value);
+    setProps(this.hostComponent, input, value);
     this.detectChanges();
   }
 }

--- a/projects/spectator/src/lib/spectator-with-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-with-routing/create-factory.ts
@@ -2,7 +2,7 @@ import { Provider, Type } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 
-import { setComponentProps } from '../internals/query';
+import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { SpectatorOverrides } from '../spectator/create-factory';
 import { isType } from '../types';
@@ -27,9 +27,9 @@ export type SpectatorWithRoutingFactory<C> = (options?: SpectatorWithRoutingOver
  * @publicApi
  */
 export function createRoutedComponentFactory<C>(typeOrOptions: Type<C> | SpectatorWithRoutingOptions<C>): SpectatorWithRoutingFactory<C> {
-  const options = isType(typeOrOptions) ?
-    getRoutingDefaultOptions<C>({ component: typeOrOptions }) :
-    getRoutingDefaultOptions(typeOrOptions);
+  const options = isType(typeOrOptions)
+    ? getRoutingDefaultOptions<C>({ component: typeOrOptions })
+    : getRoutingDefaultOptions(typeOrOptions);
 
   const moduleMetadata = initialRoutingModule<C>(options);
 
@@ -71,7 +71,7 @@ export function createRoutedComponentFactory<C>(typeOrOptions: Type<C> | Spectat
 
     const spectator = createSpectatorWithRouting(options);
 
-    setComponentProps(spectator.component, props);
+    setProps(spectator.component, props);
 
     if (options.detectChanges && detectChanges) {
       spectator.detectChanges();

--- a/projects/spectator/src/lib/spectator/create-factory.ts
+++ b/projects/spectator/src/lib/spectator/create-factory.ts
@@ -2,7 +2,7 @@ import { Provider, Type } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 
 import { BaseSpectatorOverrides } from '../base/options';
-import { setComponentProps } from '../internals/query';
+import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { isType } from '../types';
 
@@ -60,7 +60,7 @@ export function createTestComponentFactory<C>(typeOrOptions: Type<C> | Spectator
 
     const spectator = createSpectator(options);
 
-    setComponentProps(spectator.component, props);
+    setProps(spectator.component, props);
 
     if (options.detectChanges && detectChanges) {
       spectator.detectChanges();

--- a/projects/spectator/src/lib/spectator/spectator.ts
+++ b/projects/spectator/src/lib/spectator/spectator.ts
@@ -1,27 +1,20 @@
-import { ChangeDetectorRef, DebugElement, ElementRef, Type } from '@angular/core';
+import { ChangeDetectorRef, DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { Observable } from 'rxjs';
 
-import { BaseSpectator } from '../base/base-spectator';
-import { DOMSelector } from '../dom-selectors';
-import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent, dispatchTouchEvent } from '../internals/dispatch-events';
-import { patchElementFocus } from '../internals/element-focus';
-import { createMouseEvent } from '../internals/event-objects';
-import { getChildren, setComponentProps } from '../internals/query';
-import { typeInElement } from '../internals/type-in-element';
 import { SpyObject } from '../mock';
 import { Token } from '../token';
-import { isString, QueryOptions, QueryType, SpectatorElement } from '../types';
-
-const KEY_UP = 'keyup';
+import { DomSpectator } from '../base/dom-spectator';
 
 /**
  * @publicApi
  */
-export class Spectator<C> extends BaseSpectator {
-  constructor(public fixture: ComponentFixture<any>, public debugElement: DebugElement, public component: C, public element: Element) {
-    super();
+export class Spectator<C> extends DomSpectator<C> {
+  constructor(public fixture: ComponentFixture<C>, public debugElement: DebugElement, protected instance: C, public element: Element) {
+    super(fixture, debugElement, instance, element);
+  }
+
+  public get component(): C {
+    return this.instance;
   }
 
   public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
@@ -32,208 +25,11 @@ export class Spectator<C> extends BaseSpectator {
     return super.get(type);
   }
 
-  public detectChanges(): void {
-    this.fixture.detectChanges();
-  }
-
   public detectComponentChanges(): void {
     if (this.debugElement) {
       this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
     } else {
       this.detectChanges();
     }
-  }
-
-  public query<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
-  public query<R>(directive: Type<R>): R | null;
-  public query<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
-  public query<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
-    if ((options || {}).root && isString(directiveOrSelector)) {
-      return document.querySelector(directiveOrSelector);
-    }
-
-    return getChildren<R>(this.debugElement)(directiveOrSelector, options)[0] || null;
-  }
-
-  public queryAll<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R[];
-  public queryAll<R>(directive: Type<R>): R[];
-  public queryAll<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R[];
-  public queryAll<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R[] | Element[] {
-    if ((options || {}).root && isString(directiveOrSelector)) {
-      return Array.from(document.querySelectorAll(directiveOrSelector));
-    }
-
-    return getChildren<R>(this.debugElement)(directiveOrSelector, options);
-  }
-
-  public queryLast<R extends Element[]>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
-  public queryLast<R>(directive: Type<R>): R | null;
-  public queryLast<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
-  public queryLast<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
-    if ((options || {}).root && isString(directiveOrSelector)) {
-      return document.querySelector(directiveOrSelector);
-    }
-    const result = getChildren<R>(this.debugElement)(directiveOrSelector, options);
-    if (result && result.length) {
-      return result[result.length - 1];
-    }
-
-    return null;
-  }
-
-  public setInput<K extends keyof C>(input: Partial<C>): void;
-  public setInput<K extends keyof C>(input: K, inputValue: C[K]): void;
-  public setInput<K extends keyof C>(input: Partial<C> | K, value?: C[K]): void {
-    setComponentProps(this.component, input, value);
-    this.detectComponentChanges();
-  }
-
-  public output<T, K extends keyof C = keyof C>(output: K): Observable<T> {
-    const observable = this.component[output];
-
-    if (!(observable instanceof Observable)) {
-      throw new Error(`${output} is not an @Output`);
-    }
-
-    return observable as Observable<T>;
-  }
-
-  public click(selector: SpectatorElement = this.element): void {
-    const element = this.getNativeElement(selector);
-
-    if (!(element instanceof HTMLElement)) {
-      throw new Error(`Cannot click: ${selector} is not a HTMLElement`);
-    }
-
-    element.click();
-    this.detectChanges();
-  }
-
-  public blur(selector: SpectatorElement = this.element): void {
-    const element = this.getNativeElement(selector);
-
-    if (!(element instanceof HTMLElement)) {
-      throw new Error(`Cannot blur: ${selector} is not a HTMLElement`);
-    }
-
-    patchElementFocus(element);
-    element.blur();
-    this.detectChanges();
-  }
-
-  public focus(selector: SpectatorElement = this.element): void {
-    const element = this.getNativeElement(selector);
-
-    if (!(element instanceof HTMLElement)) {
-      throw new Error(`Cannot focus: ${selector} is not a HTMLElement`);
-    }
-
-    patchElementFocus(element);
-    element.focus();
-    this.detectChanges();
-  }
-
-  public dispatchMouseEvent(
-    selector: SpectatorElement = this.element,
-    type: string,
-    x: number = 0,
-    y: number = 0,
-    event: MouseEvent = createMouseEvent(type, x, y)
-  ): MouseEvent {
-    const element = this.getNativeElement(selector);
-
-    if (!(element instanceof Node)) {
-      throw new Error(`Cannot dispatch mouse event: ${selector} is not a node`);
-    }
-
-    const dispatchedEvent = dispatchMouseEvent(element, type, x, y, event);
-    this.detectChanges();
-
-    return dispatchedEvent;
-  }
-
-  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyCode: number, target?: Element): KeyboardEvent;
-  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, key: string, target?: Element): KeyboardEvent;
-  public dispatchKeyboardEvent(
-    selector: SpectatorElement = this.element,
-    type: string,
-    keyOrKeyCode: string | number,
-    target?: Element
-  ): KeyboardEvent {
-    const element = this.getNativeElement(selector);
-
-    if (!(element instanceof Node)) {
-      throw new Error(`Cannot dispatch keyboard event: ${selector} is not a node`);
-    }
-
-    const event = dispatchKeyboardEvent(element, type, keyOrKeyCode, target);
-
-    this.detectChanges();
-
-    return event;
-  }
-
-  public dispatchFakeEvent(selector: SpectatorElement = this.element, type: string, canBubble?: boolean): Event {
-    const event = dispatchFakeEvent(this.getNativeElement(selector), type, canBubble);
-    this.detectChanges();
-
-    return event;
-  }
-
-  public get keyboard(): any {
-    return {
-      pressKey: (key: string, selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, key);
-      },
-      pressEscape: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Escape');
-      },
-      pressEnter: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Enter');
-      },
-      pressTab: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Tab');
-      },
-      pressBackspace: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Backspace');
-      }
-    };
-  }
-
-  public dispatchTouchEvent(selector: SpectatorElement = this.element, type: string, x: number = 0, y: number = 0): void {
-    dispatchTouchEvent(this.getNativeElement(selector), type, x, y);
-    this.detectChanges();
-  }
-
-  public typeInElement(value: string, selector: SpectatorElement = this.element): void {
-    typeInElement(value, this.getNativeElement(selector));
-    this.detectChanges();
-  }
-
-  private getNativeElement(selector: SpectatorElement): HTMLElement | Window | Document {
-    let element;
-
-    // Support global objects window and document
-    if (selector === window || selector === document) {
-      return selector;
-    }
-
-    if (isString(selector)) {
-      const exists = this.debugElement.query(By.css(selector));
-      if (exists) {
-        element = exists.nativeElement;
-      } else {
-        // tslint:disable:no-console
-        console.error(`${selector} does not exists`);
-      }
-    } else {
-      if (selector instanceof DebugElement || selector instanceof ElementRef) {
-        element = selector.nativeElement;
-      } else {
-        element = selector;
-      }
-    }
-
-    return element;
   }
 }

--- a/projects/spectator/src/public_api.ts
+++ b/projects/spectator/src/public_api.ts
@@ -10,6 +10,15 @@ export { createHostComponentFactory, SpectatorWithHostFactory, SpectatorWithHost
 export { initialSpectatorWithHostModule } from './lib/spectator-with-host/initial-module';
 export { HostComponent, HostModule } from './lib/spectator-with-host/host-component';
 
+export { SpectatorForDirective } from './lib/spectator-for-directive/spectator-for-directive';
+export { SpectatorForDirectiveOptions } from './lib/spectator-for-directive/options';
+export {
+  createHostDirectiveFactory,
+  SpectatorForDirectiveFactory,
+  SpectatorForDirectiveOverrides
+} from './lib/spectator-for-directive/create-factory';
+export { initialSpectatorForDirectiveModule } from './lib/spectator-for-directive/initial-module';
+
 export { SpectatorService } from './lib/spectator-service/spectator-service';
 export { SpectatorServiceOptions } from './lib/spectator-service/options';
 export { SpectatorServiceFactory, createServiceFactory, SpectatorServiceOverrides } from './lib/spectator-service/create-factory';

--- a/projects/spectator/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/test/auto-focus.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostComponentFactory, createHostDirectiveFactory, SpectatorForDirective, SpectatorWithHost } from '@netbasal/spectator';
 
 import { AutoFocusDirective } from './auto-focus.directive';
 
@@ -19,6 +19,42 @@ describe('DatoAutoFocusDirective', () => {
   it('should be focused', () => {
     host = createHost(`<input datoAutoFocus="true">`);
     const instance = host.queryHost(AutoFocusDirective);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should NOT be focused', () => {
+    host = createHost(`<input [datoAutoFocus]="false">`);
+    expect(host.element).not.toBeFocused();
+  });
+
+  it('should work with dynamic input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`);
+    expect(host.element).not.toBeFocused();
+    host.setHostInput({ isFocused: true });
+    expect(host.element).toBeFocused();
+  });
+
+  it('should be able to type in input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`);
+
+    host.typeInElement('foo');
+    expect(host.element).toHaveValue('foo');
+  });
+});
+
+describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
+  let host: SpectatorForDirective<AutoFocusDirective, CustomHostComponent>;
+
+  const createHost = createHostDirectiveFactory({
+    directive: AutoFocusDirective,
+    host: CustomHostComponent
+  });
+
+  it('should be focused', () => {
+    host = createHost(`<input datoAutoFocus="true">`);
+    const instance1 = host.query(AutoFocusDirective);
+    const instance2 = host.directive;
+    expect(instance1).toBe(instance2);
     expect(host.element).toBeFocused();
   });
 


### PR DESCRIPTION
So what I basically did:

- Moved stuff from `Spectator` to abstract `DomSpectator` (for querying, event dispatching, etc) in order to reuse it
- Created new `SpectatorForDirective` which contains stuff from both `Spectator` and `SpectatorWithHost`
- it uses the host fixture, so that querying etc is done from host
- instead of `component` this one has a `directive` instance
- existing code still works (I kept the unit tests)
- added some tests for the new factory (we should have more of them I think)
- updated README