### PR TITLE
fix: CustomMatcherResult message property should be function

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -17,7 +17,7 @@ export interface CustomMatcher {
 
 export interface CustomMatcherResult {
   pass: boolean;
-  message?: string;
+  message: () => string;
 }
 
 const hasProperty = (actual: unknown, expected: unknown): boolean => {


### PR DESCRIPTION
manually passing toBeDisabled to expect.exend (expect.extend({ toBeDisabled: toBeDisabled().compare });) gives syntax errors because CustomMatcherResult has an optional message string field instead of a required function that returns string.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] ~Tests for the changes have been added (for bug fixes / features)~ NA
- [ ] ~Docs have been added / updated (for bug fixes / features)~ NA


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Manually passing a custom jest matcher to expect.extend complains that the CustomResultMatcher has an invalid message property.

Issue Number: N/A


## What is the new behavior?

No longer complains

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
