### PR TITLE
fix(matchers): toHaveStyle matcher throws TypeError error

### DIFF
--- a/projects/spectator/jest/test/highlight.directive.spec.ts
+++ b/projects/spectator/jest/test/highlight.directive.spec.ts
@@ -9,7 +9,7 @@ describe('HighlightDirective', () => {
   const createHost = createHostFactory(HighlightDirective);
 
   // calculated styles not supported in JSDOM
-  xit('should change the background color', () => {
+  it('should change the background color', () => {
     host = createHost(`<div highlight>Testing HighlightDirective</div>`);
 
     host.dispatchMouseEvent(host.element, 'mouseover');
@@ -31,7 +31,7 @@ describe('HighlightDirective (createHostDirectiveFactory)', () => {
   const createHost = createDirectiveFactory(HighlightDirective);
 
   // calculated styles not supported in JSDOM
-  xit('should change the background color', () => {
+  it('should change the background color', () => {
     host = createHost(`<div highlight>Testing HighlightDirective</div>`);
 
     host.dispatchMouseEvent(host.element, 'mouseover');

--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -11,13 +11,14 @@ interface Dummy {
   template: `
     <div id="display-none" style="display:none">Hidden with display none</div>
     <div id="visibility-hidden" style="visibility:hidden">Hidden with visibility hidden</div>
-    <label>Hidden input element<input type="hidden"/></label>
+    <label>Hidden input element<input type="hidden" /></label>
     <div hidden>Hidden by "hidden"-attribute</div>
     <div style="display:none"><div id="parent-display-none">Hidden by parent with display none</div></div>
     <div style="visibility:hidden"><div id="parent-visibility-hidden">Hidden by parent with display none</div></div>
     <div id="visible">Visible</div>
     <div id="classes" class="class-a class-b">Classes</div>
-  `
+    <div id="styles" style="background-color: indianred; color: chocolate;"></div>
+  `,
 })
 export class MatchersComponent {}
 
@@ -109,12 +110,34 @@ describe('Matchers', () => {
 
     it('should return true when expected is same as actual', () => {
       const actual: Dummy = { lorem: 'first', ipsum: 'second' };
-      expect(actual).toBePartial({...actual});
+      expect(actual).toBePartial({ ...actual });
     });
 
     it('should return false when expected is not partial of actual', () => {
       const actual: Dummy = { lorem: 'first', ipsum: 'second' };
       expect(actual).not.toBePartial({ lorem: 'second' });
+    });
+  });
+
+  describe('toHaveStyle', () => {
+    it('should return true when expected style exists on element', () => {
+      const element = spectator.query('#styles');
+      expect(element).toHaveStyle({ 'background-color': 'indianred' });
+    });
+
+    it('should return true if all styles exist on element', () => {
+      const element = spectator.query('#styles');
+      expect(element).toHaveStyle({ 'background-color': 'indianred', color: 'chocolate' });
+    });
+
+    it('should return false if style exists on an element but has a different value than expected', () => {
+      const element = spectator.query('#styles');
+      expect(element).not.toHaveStyle({ color: 'blue' });
+    });
+
+    it('should return false when expected style does not exist on element', () => {
+      const element = spectator.query('#styles');
+      expect(element).not.toHaveStyle({ height: '100px' });
     });
   });
 });

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -65,7 +65,7 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
         continue;
       }
 
-      if (trim($el.css(prop)) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
+      if (trim($el.get(0).style[prop]) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
         return false;
       }
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Fixing the bug described [in this issue](https://github.com/ngneat/spectator/issues/497)
Issue Number: 497


## What is the new behavior?
toHaveStyle throws error

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
