### PR TITLE
test: reference `jest` directly since tests fail occasionally

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:schematics": "tsc -p projects/spectator/schematics/tsconfig.json",
     "test": "ng test",
     "test:jest": "ng run spectator:test-jest",
-    "test:ci": "cross-env NODE_ENV=build yarn test && yarn test:jest",
+    "test:ci": "cross-env NODE_ENV=build yarn test && yarn test:jest --silent",
     "lint": "ng lint",
     "format": "prettier --write \"{projects,src}/**/*.ts\"",
     "commit": "git-cz",

--- a/projects/spectator/jest/src/lib/mock.ts
+++ b/projects/spectator/jest/src/lib/mock.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 import { FactoryProvider, AbstractType, Type } from '@angular/core';
 import { installProtoMethods, CompatibleSpy, SpyObject as BaseSpyObject } from '@ngneat/spectator';
 

--- a/projects/spectator/test/spectator-routing/activated-route-stub.spec.ts
+++ b/projects/spectator/test/spectator-routing/activated-route-stub.spec.ts
@@ -158,7 +158,6 @@ describe('ActivatedRouteStub', () => {
         type: 'dog'
       }
     });
-    console.error(data);
   })
 
   it('should update fragment in snapshot when set', () => {


### PR DESCRIPTION
I often get this error when running Jest tests in a watch mode:

![Screenshot from 2021-10-27 19-45-29](https://user-images.githubusercontent.com/7337691/139111648-ca0dac02-7868-45c4-8f34-e5c54d4dc00d.png)
