### PR TITLE
chore: 🤖 remove unused replace-in-file dependency

### DIFF
--- a/projects/spectator/ng-package.json
+++ b/projects/spectator/ng-package.json
@@ -7,7 +7,6 @@
   "allowedNonPeerDependencies": [
     "@testing-library/dom",
     "jquery",
-    "@types/jasmine",
-    "replace-in-file"
+    "@types/jasmine"
   ]
 }

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@testing-library/dom": "^8.11.0",
     "jquery": "^3.7.1",
-    "replace-in-file": "6.2.0",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7889,7 +7889,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.2.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
+glob@7.2.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.7:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -11599,15 +11599,6 @@ regjsparser@^0.12.0:
   dependencies:
     jsesc "~3.0.2"
 
-replace-in-file@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz"
-  integrity sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==
-  dependencies:
-    chalk "^4.1.0"
-    glob "^7.1.6"
-    yargs "^16.2.0"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
@@ -13912,7 +13903,7 @@ yargs@^15.0.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.0, yargs@^16.1.1, yargs@^16.2.0:
+yargs@^16.0.0, yargs@^16.1.1:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
✅ Closes: #706
✅ Closes: #696

Remove unused `replace-in-file` dependency

Saving `69.3kB` (https://www.npmjs.com/package/replace-in-file/v/6.2.0)

---
History of `replace-in-file` usage:

- `replace-in-file` was introduced with `migrate.js` script (https://github.com/ngneat/spectator/commit/238cff58a824e84deb860b691748e58d78ceacb8)
- `migrate.js` is removed in https://github.com/ngneat/spectator/commit/a35b33afea4a4dc89865ea8d58fe668ff6ab7369 and https://github.com/ngneat/spectator/commit/9a9be753d952f14438936e5bdbb19112958bb953

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Unused `replace-in-file` dependency

Issue Number: #706

## What is the new behavior?

Removed `replace-in-file` dependency

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
